### PR TITLE
Switch root docker-compose relay to monorepo relay build

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -1,29 +1,33 @@
-FROM oven/bun:latest AS builder
+FROM oven/bun:1 AS base
 WORKDIR /app
 
-# Copy dependency files
-COPY mini-services/relay-backend/package.json mini-services/relay-backend/bun.lock* ./
-RUN bun install --frozen-lockfile || bun install
+# Prepare pnpm for workspace dependency install
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
-# Copy source code and Prisma schema
-COPY mini-services/relay-backend/prisma ./prisma
-COPY mini-services/relay-backend/src ./src
+# Copy workspace manifests first for better layer caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+COPY services/relay/package.json ./services/relay/package.json
+COPY packages/shared-api/package.json ./packages/shared-api/package.json
+COPY packages/shared-types/package.json ./packages/shared-types/package.json
+COPY packages/shared-crypto/package.json ./packages/shared-crypto/package.json
 
-# Generate prisma client
-RUN bunx prisma generate
+# Install all workspace dependencies required by relay
+RUN pnpm install --frozen-lockfile
 
-FROM oven/bun:latest AS runner
+# Copy source code
+COPY services ./services
+COPY packages ./packages
+
+# Build relay bundle
+RUN pnpm --filter @presidium/relay build
+
+FROM oven/bun:1 AS runner
 WORKDIR /app
+ENV NODE_ENV=production
 
-# Copy production dependencies and generated client
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/prisma ./prisma
-COPY --from=builder /app/src ./src
+# Runtime artifacts
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/services/relay/dist ./services/relay/dist
 
-# Create SQLite data directory explicitly
-RUN mkdir -p /app/data
-ENV DATABASE_URL=file:/app/data/relay.db
-
-# Before starting, push prisma schema to make sure the db is created and schema is up to date
 EXPOSE 3001
-CMD ["sh", "-c", "bunx prisma db push && bun src/index.ts"]
+CMD ["bun", "services/relay/dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,15 +59,15 @@ services:
   # ─── Relay Backend ────────────────────────
   relay:
     build:
-      context: ./mini-services/relay-backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: Dockerfile.relay
     container_name: presidium-relay
     restart: unless-stopped
     ports:
       - "3001:3001"
     environment:
       - NODE_ENV=production
-      - DATABASE_URL=postgresql://presidium:${DB_PASSWORD:?Set DB_PASSWORD in .env.local}@db:5432/relay?schema=public
+      - DATABASE_URL=postgresql://presidium:${DB_PASSWORD:?Set DB_PASSWORD in .env.local}@db:5432/relay
       - REDIS_URL=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env.local}@redis:6379
       - JWT_SECRET=${JWT_SECRET:?Set JWT_SECRET in .env.local}
       - CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000


### PR DESCRIPTION
### Motivation
- The root compose stack still started the legacy relay at `mini-services/relay-backend` while the repo contains a newer monorepo relay at `services/relay`, so the compose setup must be switched to run the modern relay build. 

### Description
- Updated `docker-compose.yml` `relay` service to build from repository root using `Dockerfile.relay` instead of `./mini-services/relay-backend` and adjusted the `DATABASE_URL` to the new relay format.  
- Added/rewrote `Dockerfile.relay` to a multi-stage Bun + `pnpm` workspace build that installs workspace deps, copies `services` and `packages`, runs `pnpm --filter @presidium/relay build`, and runs the built bundle from `services/relay/dist`.  
- Included `pnpm-lock.yaml` in `Dockerfile.relay` manifest copy step to ensure reproducible workspace installs.  
- Kept changes limited to compose/build files only and avoided touching frontend, crypto, UI, or legacy backend code logic.

### Testing
- Ran `pnpm --version` and `pnpm --filter @presidium/relay -r exec true`, which succeeded.  
- Ran `pnpm --filter @presidium/relay typecheck`, which failed with `TS2688: Cannot find type definition file for 'bun-types'` (environment lacks `bun-types` definitions).  
- Attempted `docker compose config` but could not validate with Docker because the Docker CLI is not available in the environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe9f8d20c832a877b58ee79493567)