### PR TITLE
Phase B1: implement canonical user identity bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,12 @@ NEXT_PUBLIC_RELAY_HTTP_URL="http://localhost:3001"
 # WebSocket URL for relay signaling
 NEXT_PUBLIC_RELAY_WS_URL="ws://localhost:3001/ws"
 
+# Server-side relay URL for Next.js API routes (optional fallback to NEXT_PUBLIC_RELAY_HTTP_URL)
+RELAY_HTTP_URL="http://localhost:3001"
+
+# Shared internal key used by web server to call relay Phase B1 identity bridge endpoint
+INTERNAL_API_KEY=""
+
 # JWT secret for relay backend
 # You can reuse NEXTAUTH_SECRET in local dev
 JWT_SECRET="your-relay-jwt-secret-here"

--- a/.env.production.example
+++ b/.env.production.example
@@ -26,7 +26,9 @@ AI_PROVIDER="glm4"
 # ===========================================
 NEXT_PUBLIC_RELAY_HTTP_URL="http://localhost:3001"
 NEXT_PUBLIC_RELAY_WS_URL="ws://localhost:3001/ws"
+RELAY_HTTP_URL="http://relay:3001"
 JWT_SECRET="your-relay-jwt-secret-here"
+INTERNAL_API_KEY="set-a-strong-shared-internal-key"
 CORS_ORIGINS="http://localhost:3000,http://localhost:3001"
 
 # ===========================================

--- a/docs/engineering/phase-b1-user-identity-contract.md
+++ b/docs/engineering/phase-b1-user-identity-contract.md
@@ -315,6 +315,24 @@ Pragmatic transition option:
 Option B is acceptable temporarily if documented and isolated in one helper.
 ```
 
+### 7.5 `public_key` placeholder note (transition-only)
+
+Current relay users schema keeps `users.public_key` as `NOT NULL`.
+
+Phase B1 identity bridge does **not** migrate or generate private E2EE key material.
+If a bridge create path must satisfy `NOT NULL`, it may use a clearly marked temporary
+placeholder value (for example `pending:<legacyWebUserId>`) until the normal pre-key
+upload flow stores the real public key material.
+
+Rules:
+
+```text
+placeholder must be documented and easy to detect
+placeholder must never include private keys
+placeholder must never include plaintext message content
+Phase B1 must not repurpose bridge code to store private E2EE secrets
+```
+
 ---
 
 ## 8. Forbidden implementation shortcuts

--- a/services/relay/drizzle/0000_phase_b1_identity_bridge.sql
+++ b/services/relay/drizzle/0000_phase_b1_identity_bridge.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "users" ADD COLUMN "legacy_web_user_id" text;
+CREATE UNIQUE INDEX "users_legacy_web_user_id_idx"
+  ON "users" ("legacy_web_user_id")
+  WHERE "users"."legacy_web_user_id" IS NOT NULL;

--- a/services/relay/src/auth/jwt.ts
+++ b/services/relay/src/auth/jwt.ts
@@ -14,6 +14,7 @@ const SECRET = new TextEncoder().encode(config.JWT_SECRET);
 export interface TokenPayload extends JWTPayload {
   sub: string;
   email: string;
+  legacyWebUserId?: string;
   deviceId?: string;
   tier?: 'free' | 'local_ai' | 'cloud_ai';
 }

--- a/services/relay/src/db/schema.ts
+++ b/services/relay/src/db/schema.ts
@@ -35,6 +35,7 @@ export const users = pgTable(
     id: uuid('id').defaultRandom().primaryKey(),
     name: varchar('name', { length: 255 }).notNull(),
     email: varchar('email', { length: 255 }).notNull().unique(),
+    legacyWebUserId: text('legacy_web_user_id'),
     passwordHash: text('password_hash'),
     avatar: text('avatar'),
     publicKey: text('public_key').notNull(),
@@ -51,6 +52,9 @@ export const users = pgTable(
   },
   (table) => [
     uniqueIndex('users_email_idx').on(table.email),
+    uniqueIndex('users_legacy_web_user_id_idx')
+      .on(table.legacyWebUserId)
+      .where(sql`${table.legacyWebUserId} IS NOT NULL`),
     index('users_status_idx').on(table.status),
     index('users_presence_idx').on(table.presenceStatus),
     index('users_created_idx').on(table.createdAt),

--- a/services/relay/src/index.ts
+++ b/services/relay/src/index.ts
@@ -26,6 +26,7 @@ import marketplaceRouter from './routes/marketplace.js';
 import booksRouter from './routes/books.js';
 import subscriptionsRouter from './routes/subscriptions.js';
 import adminRouter from './routes/admin.js';
+import internalRouter from './routes/internal.js';
 import { getLocalConnectionCount, publishToLocalUser, wsHandler } from './ws/handler.js';
 
 const PORT = config.PORT;
@@ -69,6 +70,7 @@ httpApp.route('/marketplace', marketplaceRouter);
 httpApp.route('/books', booksRouter);
 httpApp.route('/subscriptions', subscriptionsRouter);
 httpApp.route('/admin', adminRouter);
+httpApp.route('/internal', internalRouter);
 
 httpApp.notFound((c) => {
   return c.json(

--- a/services/relay/src/routes/internal.ts
+++ b/services/relay/src/routes/internal.ts
@@ -1,0 +1,111 @@
+import { Hono } from 'hono';
+import { and, eq, isNull, or } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { db } from '../db/index.js';
+import { users } from '../db/schema.js';
+
+const app = new Hono();
+
+const syncWebUserSchema = z.object({
+  legacyWebUserId: z.string().min(1),
+  email: z.string().email(),
+  name: z.string().trim().min(1).max(255).optional(),
+  avatar: z.string().trim().max(4096).optional(),
+});
+
+function getInternalApiKey(): string {
+  return process.env.INTERNAL_API_KEY || '';
+}
+
+function hasValidInternalAuthHeader(header: string | undefined): boolean {
+  const internalApiKey = getInternalApiKey();
+  if (!internalApiKey || !header) {
+    return false;
+  }
+  return header === `Bearer ${internalApiKey}`;
+}
+
+app.post('/users/sync-web-user', async (c) => {
+  const authHeader = c.req.header('authorization') || c.req.header('Authorization');
+  if (!hasValidInternalAuthHeader(authHeader)) {
+    return c.json({ success: false, error: 'Unauthorized', code: 'AUTH_MISSING' }, 401);
+  }
+
+  const body = await c.req.json().catch(() => null);
+  const parsed = syncWebUserSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      {
+        success: false,
+        error: 'Invalid sync payload',
+        code: 'VALIDATION_ERROR',
+        details: parsed.error.flatten(),
+      },
+      400
+    );
+  }
+
+  const now = new Date();
+  const relayName = parsed.data.name?.trim() || parsed.data.email;
+  const relayAvatar = parsed.data.avatar?.trim() || '';
+
+  const matchByLegacy = eq(users.legacyWebUserId, parsed.data.legacyWebUserId);
+  const matchByEmailWithoutLegacy = and(
+    eq(users.email, parsed.data.email),
+    isNull(users.legacyWebUserId)
+  );
+
+  const existing = await db.query.users.findFirst({
+    where: or(matchByLegacy, matchByEmailWithoutLegacy),
+    columns: {
+      id: true,
+    },
+  });
+
+  if (!existing) {
+    const [created] = await db
+      .insert(users)
+      .values({
+        legacyWebUserId: parsed.data.legacyWebUserId,
+        email: parsed.data.email,
+        name: relayName,
+        avatar: relayAvatar,
+        publicKey: `pending:${parsed.data.legacyWebUserId}`,
+        updatedAt: now,
+      })
+      .returning({
+        id: users.id,
+      });
+
+    return c.json({
+      success: true,
+      data: {
+        relayUserId: created.id,
+      },
+    });
+  }
+
+  const [updated] = await db
+    .update(users)
+    .set({
+      legacyWebUserId: parsed.data.legacyWebUserId,
+      email: parsed.data.email,
+      name: relayName,
+      avatar: relayAvatar,
+      updatedAt: now,
+    })
+    .where(eq(users.id, existing.id))
+    .returning({
+      id: users.id,
+    });
+
+  return c.json({
+    success: true,
+    data: {
+      relayUserId: updated.id,
+    },
+  });
+});
+
+export default app;

--- a/services/relay/src/routes/internal.ts
+++ b/services/relay/src/routes/internal.ts
@@ -29,7 +29,7 @@ function hasValidInternalAuthHeader(header: string | undefined): boolean {
 app.post('/users/sync-web-user', async (c) => {
   const authHeader = c.req.header('authorization') || c.req.header('Authorization');
   if (!hasValidInternalAuthHeader(authHeader)) {
-    return c.json({ success: false, error: 'Unauthorized', code: 'AUTH_MISSING' }, 401);
+    return c.json({ success: false, error: 'Unauthorized', code: 'IDENTITY_AUTH_INVALID' }, 401);
   }
 
   const body = await c.req.json().catch(() => null);
@@ -64,26 +64,50 @@ app.post('/users/sync-web-user', async (c) => {
   });
 
   if (!existing) {
-    const [created] = await db
-      .insert(users)
-      .values({
-        legacyWebUserId: parsed.data.legacyWebUserId,
-        email: parsed.data.email,
-        name: relayName,
-        avatar: relayAvatar,
-        publicKey: `pending:${parsed.data.legacyWebUserId}`,
-        updatedAt: now,
-      })
-      .returning({
-        id: users.id,
-      });
+    try {
+      const [created] = await db
+        .insert(users)
+        .values({
+          legacyWebUserId: parsed.data.legacyWebUserId,
+          email: parsed.data.email,
+          name: relayName,
+          avatar: relayAvatar,
+          /**
+           * Phase B1 transition placeholder.
+           * `users.public_key` is currently not-null in relay schema, but web identity bridge
+           * does not create or migrate E2EE key material.
+           * Real public key upload remains handled by the pre-key/e2ee flow.
+           */
+          publicKey: `pending:${parsed.data.legacyWebUserId}`,
+          updatedAt: now,
+        })
+        .returning({
+          id: users.id,
+        });
 
-    return c.json({
-      success: true,
-      data: {
-        relayUserId: created.id,
-      },
-    });
+      return c.json({
+        success: true,
+        data: {
+          relayUserId: created.id,
+        },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '';
+      if (
+        message.includes('users_legacy_web_user_id_idx') ||
+        message.includes('users_email_idx') ||
+        message.includes('duplicate key')
+      ) {
+        return c.json(
+          { success: false, error: 'Identity mapping conflict', code: 'IDENTITY_CONFLICT' },
+          409
+        );
+      }
+      return c.json(
+        { success: false, error: 'Failed to create relay identity', code: 'IDENTITY_CREATE_FAILED' },
+        500
+      );
+    }
   }
 
   const [updated] = await db

--- a/services/relay/src/routes/keys.ts
+++ b/services/relay/src/routes/keys.ts
@@ -76,6 +76,25 @@ function bundleKey(userId: string): string {
   return `prekeys:bundle:${userId}`;
 }
 
+function bundleAliasKey(userId: string): string {
+  return `prekeys:alias:${userId}`;
+}
+
+async function resolveBundleKey(userId: string): Promise<string> {
+  const directKey = bundleKey(userId);
+  const directBundle = await redis.get(directKey);
+  if (directBundle) {
+    return directKey;
+  }
+
+  const canonicalUserId = await redis.get(bundleAliasKey(userId));
+  if (!canonicalUserId) {
+    return directKey;
+  }
+
+  return bundleKey(canonicalUserId);
+}
+
 function normalizeBundle(userId: string, input: z.infer<typeof preKeyUploadSchema>): StoredPreKeyBundle {
   const signedPreKey =
     typeof input.signedPreKey === 'string'
@@ -144,6 +163,17 @@ app.post('/upload', apiRateLimit, async (c) => {
 
   const bundle = normalizeBundle(tokenPayload.sub, parsed.data);
   await redis.set(bundleKey(tokenPayload.sub), JSON.stringify(bundle), 'EX', PREKEY_BUNDLE_TTL_SECONDS);
+  const legacyWebUserId = typeof tokenPayload.legacyWebUserId === 'string'
+    ? tokenPayload.legacyWebUserId.trim()
+    : '';
+  if (legacyWebUserId && legacyWebUserId !== tokenPayload.sub) {
+    await redis.set(
+      bundleAliasKey(legacyWebUserId),
+      tokenPayload.sub,
+      'EX',
+      PREKEY_BUNDLE_TTL_SECONDS
+    );
+  }
 
   return c.json({
     success: true,
@@ -158,7 +188,7 @@ app.post('/upload', apiRateLimit, async (c) => {
 
 app.get('/:userId', apiRateLimit, async (c) => {
   const userId = c.req.param('userId');
-  const rawBundle = await redis.get(bundleKey(userId));
+  const rawBundle = await redis.get(await resolveBundleKey(userId));
 
   if (!rawBundle) {
     return c.json(

--- a/src/app/api/relay/token/route.ts
+++ b/src/app/api/relay/token/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from 'next-auth';
 import { sign } from 'jsonwebtoken';
 import { authOptions } from '@/lib/auth-options';
 import { rateLimit } from '@/lib/rate-limit';
-import { resolveRelayIdentity } from '@/lib/server/relay-identity';
+import { RelayIdentityError, resolveRelayIdentity } from '@/lib/server/relay-identity';
 
 const EXPIRES_IN_SECONDS = 2 * 60 * 60;
 const RELAY_TOKEN_ISSUER = 'presidium-api';
@@ -58,7 +58,16 @@ export async function POST(request: NextRequest) {
       issuer: RELAY_TOKEN_ISSUER,
       audience: RELAY_TOKEN_AUDIENCE,
     });
-  } catch {
-    return NextResponse.json({ error: 'Failed to issue relay token' }, { status: 500 });
+  } catch (error) {
+    if (error instanceof RelayIdentityError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.status }
+      );
+    }
+    return NextResponse.json(
+      { error: 'Failed to issue relay token', code: 'RELAY_TOKEN_ISSUE_FAILED' },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/relay/token/route.ts
+++ b/src/app/api/relay/token/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { sign } from 'jsonwebtoken';
 import { authOptions } from '@/lib/auth-options';
 import { rateLimit } from '@/lib/rate-limit';
+import { resolveRelayIdentity } from '@/lib/server/relay-identity';
 
 const EXPIRES_IN_SECONDS = 2 * 60 * 60;
 const RELAY_TOKEN_ISSUER = 'presidium-api';
@@ -34,10 +35,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'JWT secret is not configured' }, { status: 500 });
     }
 
+    const relayIdentity = await resolveRelayIdentity(session.user);
+
     const token = sign(
       {
-        sub: session.user.id,
-        id: session.user.id,
+        sub: relayIdentity.relayUserId,
+        id: relayIdentity.relayUserId,
+        legacyWebUserId: session.user.id,
         email: session.user.email || '',
       },
       secret,

--- a/src/lib/server/relay-identity.ts
+++ b/src/lib/server/relay-identity.ts
@@ -11,17 +11,28 @@ type RelayIdentityResult = {
   relayUserId: string;
 };
 
+export class RelayIdentityError extends Error {
+  code: string;
+  status: number;
+
+  constructor(message: string, code: string, status = 500) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+
 export async function resolveRelayIdentity(user: RelayIdentityInput): Promise<RelayIdentityResult> {
   if (!user.id) {
-    throw new Error('Missing web user ID');
+    throw new RelayIdentityError('Missing web user ID', 'IDENTITY_WEB_ID_MISSING', 400);
   }
   if (!user.email) {
-    throw new Error('Missing web user email');
+    throw new RelayIdentityError('Missing web user email', 'IDENTITY_EMAIL_MISSING', 400);
   }
 
   const internalApiKey = process.env.INTERNAL_API_KEY || '';
   if (!internalApiKey) {
-    throw new Error('INTERNAL_API_KEY is not configured');
+    throw new RelayIdentityError('INTERNAL_API_KEY is not configured', 'IDENTITY_BRIDGE_CONFIG_MISSING', 500);
   }
 
   const response = await fetch(`${getRelayHttpBaseUrl()}/internal/users/sync-web-user`, {
@@ -40,7 +51,12 @@ export async function resolveRelayIdentity(user: RelayIdentityInput): Promise<Re
   });
 
   if (!response.ok) {
-    throw new Error(`Relay identity sync failed (${response.status})`);
+    const payload = (await response.json().catch(() => null)) as { code?: string; error?: string } | null;
+    throw new RelayIdentityError(
+      payload?.error || `Relay identity sync failed (${response.status})`,
+      payload?.code || 'IDENTITY_BRIDGE_REQUEST_FAILED',
+      response.status
+    );
   }
 
   const payload = (await response.json()) as {
@@ -49,7 +65,11 @@ export async function resolveRelayIdentity(user: RelayIdentityInput): Promise<Re
   };
   const relayUserId = payload.data?.relayUserId;
   if (!payload.success || !relayUserId) {
-    throw new Error('Relay identity sync returned invalid response');
+    throw new RelayIdentityError(
+      'Relay identity sync returned invalid response',
+      'IDENTITY_BRIDGE_INVALID_RESPONSE',
+      502
+    );
   }
 
   return { relayUserId };

--- a/src/lib/server/relay-identity.ts
+++ b/src/lib/server/relay-identity.ts
@@ -1,0 +1,56 @@
+import { getRelayHttpBaseUrl } from '@/lib/relay-base-url';
+
+type RelayIdentityInput = {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  avatar?: string | null;
+};
+
+type RelayIdentityResult = {
+  relayUserId: string;
+};
+
+export async function resolveRelayIdentity(user: RelayIdentityInput): Promise<RelayIdentityResult> {
+  if (!user.id) {
+    throw new Error('Missing web user ID');
+  }
+  if (!user.email) {
+    throw new Error('Missing web user email');
+  }
+
+  const internalApiKey = process.env.INTERNAL_API_KEY || '';
+  if (!internalApiKey) {
+    throw new Error('INTERNAL_API_KEY is not configured');
+  }
+
+  const response = await fetch(`${getRelayHttpBaseUrl()}/internal/users/sync-web-user`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${internalApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      legacyWebUserId: user.id,
+      email: user.email,
+      name: user.name || undefined,
+      avatar: user.avatar || undefined,
+    }),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Relay identity sync failed (${response.status})`);
+  }
+
+  const payload = (await response.json()) as {
+    success?: boolean;
+    data?: { relayUserId?: string };
+  };
+  const relayUserId = payload.data?.relayUserId;
+  if (!payload.success || !relayUserId) {
+    throw new Error('Relay identity sync returned invalid response');
+  }
+
+  return { relayUserId };
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, idempotent bridge from legacy web `cuid()` user IDs to canonical relay/Postgres UUID users so new relay tokens use canonical UUID subjects while preserving legacy compatibility. 
- Keep the change scoped to Phase B1 only and avoid touching Phase B2-B5 responsibilities or E2EE/private key storage and logging rules.

### Description
- Added a persistent mapping `legacy_web_user_id` to the relay users schema (Drizzle) plus a unique partial index and included a SQL migration file to create the column and index. 
- Implemented an internal relay endpoint `POST /internal/users/sync-web-user` that authenticates with `INTERNAL_API_KEY`, validates the safe profile fields (`legacyWebUserId`, `email`, `name`, `avatar`), and idempotently resolves or creates a canonical relay user returning `relayUserId`, and mounted it under `/internal`. 
- Added a server-side web helper `resolveRelayIdentity` which calls the internal relay endpoint, and updated the web `/api/relay/token` route to issue JWTs with `sub` and `id` set to the canonical relay UUID and `legacyWebUserId` set to the current web `session.user.id`, while preserving issuer, audience, expiresIn, rate-limits, and legacy token compatibility. 
- Security/privacy notes and migration/rollback summary: the internal route requires `INTERNAL_API_KEY`, only safe profile fields are upserted, no plaintext messages or private E2EE keys are stored or logged, run the provided Drizzle/SQL migration to add `legacy_web_user_id` and the unique index, ensure `INTERNAL_API_KEY` is set in web and relay environments for identity bridging, and rollback is possible by reverting this change and removing the internal route and DB migration (and optionally dropping the `legacy_web_user_id` column). Known limitation: canonical resolution depends on relay availability and the internal API bridge at token issuance time and new links fall back to an email-match only when `legacy_web_user_id` is null. 

### Testing
- `pnpm install --no-frozen-lockfile` could not complete in this environment due to external registry/network/postinstall failures (e.g., `onnxruntime-node` postinstall ENETUNREACH). 
- Package builds and checks that ran successfully in this environment include `pnpm --filter @presidium/shared-types build`, `pnpm --filter @presidium/shared-api build`, `pnpm --filter @presidium/shared-crypto build`, `pnpm --filter @presidium/shared-ui build`, `pnpm --filter @presidium/relay typecheck`, and `pnpm --filter @presidium/relay build`, and `pnpm --filter @presidium/web typecheck`. 
- `pnpm --filter @presidium/web build` failed here because the `next` binary was unavailable after the incomplete install, and `docker compose config` could not be run because `docker` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0926dd994832a9901ee5d83d7f67c)