### PR TITLE
Phase B2: implement canonical private chat creation

### DIFF
--- a/services/relay/drizzle/0001_phase_b2_private_chat_creation.sql
+++ b/services/relay/drizzle/0001_phase_b2_private_chat_creation.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "chats"
+ADD COLUMN IF NOT EXISTS "private_pair_key" text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "chats_private_pair_key_idx"
+ON "chats" ("private_pair_key")
+WHERE "private_pair_key" IS NOT NULL;

--- a/services/relay/src/db/schema.ts
+++ b/services/relay/src/db/schema.ts
@@ -72,6 +72,7 @@ export const chats = pgTable(
     name: varchar('name', { length: 255 }),
     avatar: text('avatar'),
     isEncrypted: boolean('is_encrypted').default(true).notNull(),
+    privatePairKey: text('private_pair_key'),
     createdBy: uuid('created_by').references(() => users.id, { onDelete: 'set null' }),
     ephemeralTimer: integer('ephemeral_timer').default(0),
     isPublic: boolean('is_public').default(false),
@@ -80,6 +81,9 @@ export const chats = pgTable(
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (table) => [
+    uniqueIndex('chats_private_pair_key_idx')
+      .on(table.privatePairKey)
+      .where(sql`${table.privatePairKey} IS NOT NULL`),
     index('chats_type_idx').on(table.type),
     index('chats_created_idx').on(table.createdAt),
     index('chats_createdby_idx').on(table.createdBy),

--- a/services/relay/src/routes/internal.ts
+++ b/services/relay/src/routes/internal.ts
@@ -3,7 +3,7 @@ import { and, eq, isNull, or } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { db } from '../db/index.js';
-import { users } from '../db/schema.js';
+import { chatMembers, chats, users } from '../db/schema.js';
 
 const app = new Hono();
 
@@ -13,6 +13,25 @@ const syncWebUserSchema = z.object({
   name: z.string().trim().min(1).max(255).optional(),
   avatar: z.string().trim().max(4096).optional(),
 });
+
+const upsertPrivateChatSchema = z
+  .object({
+    requesterRelayUserId: z.string().uuid(),
+    recipientRelayUserId: z.string().uuid().optional(),
+    recipientLegacyWebUserId: z.string().min(1).optional(),
+    recipientEmail: z.string().email().optional(),
+    recipientName: z.string().trim().min(1).max(255).optional(),
+    recipientAvatar: z.string().trim().max(4096).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.recipientRelayUserId && !value.recipientLegacyWebUserId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['recipientLegacyWebUserId'],
+        message: 'Recipient identifier is required',
+      });
+    }
+  });
 
 function getInternalApiKey(): string {
   return process.env.INTERNAL_API_KEY || '';
@@ -24,6 +43,10 @@ function hasValidInternalAuthHeader(header: string | undefined): boolean {
     return false;
   }
   return header === `Bearer ${internalApiKey}`;
+}
+
+function buildPrivatePairKey(userA: string, userB: string): string {
+  return [userA, userB].sort().join(':');
 }
 
 app.post('/users/sync-web-user', async (c) => {
@@ -130,6 +153,182 @@ app.post('/users/sync-web-user', async (c) => {
       relayUserId: updated.id,
     },
   });
+});
+
+app.post('/chats/private/upsert', async (c) => {
+  const authHeader = c.req.header('authorization') || c.req.header('Authorization');
+  if (!hasValidInternalAuthHeader(authHeader)) {
+    return c.json({ success: false, error: 'Unauthorized', code: 'IDENTITY_AUTH_INVALID' }, 401);
+  }
+
+  const body = await c.req.json().catch(() => null);
+  const parsed = upsertPrivateChatSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      {
+        success: false,
+        error: 'Invalid private chat payload',
+        code: 'VALIDATION_ERROR',
+        details: parsed.error.flatten(),
+      },
+      400
+    );
+  }
+
+  const payload = parsed.data;
+
+  if (payload.requesterRelayUserId === payload.recipientRelayUserId) {
+    return c.json(
+      {
+        success: false,
+        error: 'Cannot create private chat with self',
+        code: 'VALIDATION_ERROR',
+      },
+      400
+    );
+  }
+
+  const requester = await db.query.users.findFirst({
+    where: eq(users.id, payload.requesterRelayUserId),
+    columns: { id: true },
+  });
+
+  if (!requester) {
+    return c.json(
+      { success: false, error: 'Requester identity not found', code: 'REQUESTER_NOT_FOUND' },
+      404
+    );
+  }
+
+  let recipientRelayUserId = payload.recipientRelayUserId || null;
+
+  if (!recipientRelayUserId && payload.recipientLegacyWebUserId) {
+    const recipient = await db.query.users.findFirst({
+      where: eq(users.legacyWebUserId, payload.recipientLegacyWebUserId),
+      columns: { id: true },
+    });
+
+    if (recipient) {
+      recipientRelayUserId = recipient.id;
+    }
+  }
+
+  if (!recipientRelayUserId && payload.recipientLegacyWebUserId && payload.recipientEmail) {
+    const relayName = payload.recipientName?.trim() || payload.recipientEmail;
+    const relayAvatar = payload.recipientAvatar?.trim() || '';
+    const now = new Date();
+
+    try {
+      const [created] = await db
+        .insert(users)
+        .values({
+          legacyWebUserId: payload.recipientLegacyWebUserId,
+          email: payload.recipientEmail,
+          name: relayName,
+          avatar: relayAvatar,
+          publicKey: `pending:${payload.recipientLegacyWebUserId}`,
+          updatedAt: now,
+        })
+        .returning({ id: users.id });
+      recipientRelayUserId = created.id;
+    } catch {
+      const retry = await db.query.users.findFirst({
+        where: eq(users.legacyWebUserId, payload.recipientLegacyWebUserId),
+        columns: { id: true },
+      });
+      recipientRelayUserId = retry?.id || null;
+    }
+  }
+
+  if (!recipientRelayUserId) {
+    return c.json(
+      { success: false, error: 'Recipient identity not found', code: 'RECIPIENT_NOT_FOUND' },
+      404
+    );
+  }
+
+  if (payload.requesterRelayUserId === recipientRelayUserId) {
+    return c.json(
+      {
+        success: false,
+        error: 'Cannot create private chat with self',
+        code: 'VALIDATION_ERROR',
+      },
+      400
+    );
+  }
+
+  const pairKey = buildPrivatePairKey(payload.requesterRelayUserId, recipientRelayUserId);
+
+  try {
+    const result = await db.transaction(async (tx) => {
+      const existing = await tx.query.chats.findFirst({
+        where: eq(chats.privatePairKey, pairKey),
+        columns: {
+          id: true,
+          type: true,
+          isEncrypted: true,
+          createdAt: true,
+        },
+      });
+
+      if (existing) {
+        await tx
+          .insert(chatMembers)
+          .values([
+            { chatId: existing.id, userId: payload.requesterRelayUserId, role: 'owner' },
+            { chatId: existing.id, userId: recipientRelayUserId, role: 'member' },
+          ])
+          .onConflictDoNothing();
+
+        return { chat: existing, reused: true };
+      }
+
+      const [chat] = await tx
+        .insert(chats)
+        .values({
+          type: 'private',
+          isEncrypted: true,
+          createdBy: payload.requesterRelayUserId,
+          privatePairKey: pairKey,
+        })
+        .returning({
+          id: chats.id,
+          type: chats.type,
+          isEncrypted: chats.isEncrypted,
+          createdAt: chats.createdAt,
+        });
+
+      await tx.insert(chatMembers).values([
+        { chatId: chat.id, userId: payload.requesterRelayUserId, role: 'owner' },
+        { chatId: chat.id, userId: recipientRelayUserId, role: 'member' },
+      ]);
+
+      return { chat, reused: false };
+    });
+
+    return c.json({
+      success: true,
+      data: {
+        id: result.chat.id,
+        type: result.chat.type,
+        isEncrypted: result.chat.isEncrypted,
+        createdAt: result.chat.createdAt,
+        memberIds: [payload.requesterRelayUserId, recipientRelayUserId],
+        mode: 'canonical_postgres',
+        reused: result.reused,
+      },
+    });
+  } catch {
+    return c.json(
+      {
+        success: false,
+        error: 'Failed to upsert private chat',
+        code: 'PRIVATE_CHAT_CREATE_FAILED',
+      },
+      500
+    );
+  }
 });
 
 export default app;

--- a/src/app/api/chats/private/route.ts
+++ b/src/app/api/chats/private/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+
+import { authOptions } from '@/lib/auth-options';
+import { rateLimit } from '@/lib/rate-limit';
+import {
+  CanonicalPrivateChatError,
+  createCanonicalPrivateChat,
+} from '@/lib/server/relay-private-chat';
+
+const createPrivateChatSchema = z.object({
+  recipientId: z.string().min(1),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized', code: 'NO_WEB_SESSION' },
+        { status: 401 },
+      );
+    }
+
+    const limit = rateLimit(`chats:private:create:${session.user.id}`, {
+      maxRequests: 20,
+      windowMs: 60 * 1000,
+    });
+
+    if (!limit.success) {
+      return NextResponse.json(
+        { success: false, error: 'Too many chat creation requests', code: 'RATE_LIMITED' },
+        { status: 429 },
+      );
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsed = createPrivateChatSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid input',
+          code: 'VALIDATION_ERROR',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 },
+      );
+    }
+
+    const chat = await createCanonicalPrivateChat(session.user, parsed.data.recipientId);
+
+    return NextResponse.json({
+      success: true,
+      chat: {
+        id: chat.chatId,
+        type: 'private',
+        memberIds: chat.memberIds,
+        mode: 'canonical_postgres',
+      },
+      reused: chat.reused,
+    });
+  } catch (error) {
+    if (error instanceof CanonicalPrivateChatError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: error.message,
+          code: error.code,
+        },
+        { status: error.status },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to create private chat',
+        code: 'PRIVATE_CHAT_CREATE_FAILED',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/chats/route.ts
+++ b/src/app/api/chats/route.ts
@@ -3,6 +3,10 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth-options';
 import { db } from '@/lib/db';
 import { rateLimit } from '@/lib/rate-limit';
+import {
+  CanonicalPrivateChatError,
+  createCanonicalPrivateChat,
+} from '@/lib/server/relay-private-chat';
 import { z } from 'zod';
 
 const createChatSchema = z
@@ -171,76 +175,35 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      const targetUser = await db.user.findUnique({
-        where: { id: targetId },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          avatar: true,
-          status: true,
-        },
-      });
+      try {
+        const canonical = await createCanonicalPrivateChat(session.user, targetId);
 
-      if (!targetUser) {
         return NextResponse.json(
-          { error: 'Target user not found' },
-          { status: 404 },
+          {
+            success: true,
+            chat: {
+              id: canonical.chatId,
+              type: 'private',
+              isEncrypted: true,
+              encryptionType: 'e2e',
+              mode: 'canonical_postgres',
+              memberIds: canonical.memberIds,
+            },
+            reused: canonical.reused,
+          },
+          { status: canonical.reused ? 200 : 201 },
         );
-      }
-
-      // Reuse existing private chat between the same two users.
-      const existingPrivateCandidates = await db.chat.findMany({
-        where: {
-          type: 'private',
-          members: {
-            some: { userId: session.user.id },
-          },
-          AND: [
-            {
-              members: {
-                some: { userId: targetId },
-              },
-            },
-          ],
-        },
-        include: {
-          members: {
-            include: {
-              user: {
-                select: {
-                  id: true,
-                  name: true,
-                  email: true,
-                  avatar: true,
-                  status: true,
-                },
-              },
-            },
-          },
-        },
-      });
-
-      const existingPrivate = existingPrivateCandidates.find((candidate) => {
-        const ids = candidate.members.map((member) => member.userId);
-        return ids.length === 2 && ids.includes(session.user.id) && ids.includes(targetId);
-      });
-
-      if (existingPrivate) {
-        return NextResponse.json({
-          success: true,
-          chat: {
-            id: existingPrivate.id,
-            name: existingPrivate.name,
-            type: existingPrivate.type,
-            avatar: existingPrivate.avatar,
-            isEncrypted: existingPrivate.isEncrypted,
-            encryptionType: existingPrivate.encryptionType,
-            members: existingPrivate.members.map((m) => m.user),
-            createdAt: existingPrivate.createdAt,
-          },
-          reused: true,
-        });
+      } catch (error) {
+        if (error instanceof CanonicalPrivateChatError) {
+          return NextResponse.json(
+            { error: error.message, code: error.code },
+            { status: error.status },
+          );
+        }
+        return NextResponse.json(
+          { error: 'Failed to create private chat', code: 'PRIVATE_CHAT_CREATE_FAILED' },
+          { status: 500 },
+        );
       }
     }
 
@@ -310,4 +273,3 @@ export async function POST(request: NextRequest) {
     );
   }
 }
-

--- a/src/lib/server/relay-private-chat.ts
+++ b/src/lib/server/relay-private-chat.ts
@@ -1,0 +1,130 @@
+import { db } from '@/lib/db';
+import { getRelayHttpBaseUrl } from '@/lib/relay-base-url';
+import { resolveRelayIdentity } from '@/lib/server/relay-identity';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+
+type WebUser = {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  avatar?: string | null;
+};
+
+type CanonicalPrivateChatResult = {
+  chatId: string;
+  memberIds: string[];
+  reused: boolean;
+};
+
+export class CanonicalPrivateChatError extends Error {
+  code: string;
+  status: number;
+
+  constructor(message: string, code: string, status = 500) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export async function createCanonicalPrivateChat(
+  requester: WebUser,
+  recipientId: string,
+): Promise<CanonicalPrivateChatResult> {
+  const requesterIdentity = await resolveRelayIdentity(requester);
+
+  const payload: {
+    requesterRelayUserId: string;
+    recipientRelayUserId?: string;
+    recipientLegacyWebUserId?: string;
+    recipientEmail?: string;
+    recipientName?: string;
+    recipientAvatar?: string;
+  } = {
+    requesterRelayUserId: requesterIdentity.relayUserId,
+  };
+
+  if (isUuid(recipientId)) {
+    payload.recipientRelayUserId = recipientId;
+  } else {
+    const recipient = await db.user.findUnique({
+      where: { id: recipientId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        avatar: true,
+      },
+    });
+
+    if (!recipient) {
+      throw new CanonicalPrivateChatError('Recipient not found', 'RECIPIENT_NOT_FOUND', 404);
+    }
+
+    payload.recipientLegacyWebUserId = recipient.id;
+    if (recipient.email) {
+      payload.recipientEmail = recipient.email;
+    }
+    if (recipient.name) {
+      payload.recipientName = recipient.name;
+    }
+    if (recipient.avatar) {
+      payload.recipientAvatar = recipient.avatar;
+    }
+  }
+
+  const internalApiKey = process.env.INTERNAL_API_KEY || '';
+  if (!internalApiKey) {
+    throw new CanonicalPrivateChatError(
+      'INTERNAL_API_KEY is not configured',
+      'IDENTITY_BRIDGE_CONFIG_MISSING',
+      500,
+    );
+  }
+
+  const response = await fetch(`${getRelayHttpBaseUrl()}/internal/chats/private/upsert`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${internalApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    const errorPayload = (await response.json().catch(() => null)) as
+      | { code?: string; error?: string }
+      | null;
+
+    throw new CanonicalPrivateChatError(
+      errorPayload?.error || `Private chat upsert failed (${response.status})`,
+      errorPayload?.code || 'PRIVATE_CHAT_CREATE_FAILED',
+      response.status,
+    );
+  }
+
+  const data = (await response.json()) as {
+    success?: boolean;
+    data?: { id?: string; memberIds?: string[]; reused?: boolean };
+  };
+
+  if (!data.success || !data.data?.id || !Array.isArray(data.data.memberIds)) {
+    throw new CanonicalPrivateChatError(
+      'Private chat upsert returned invalid response',
+      'PRIVATE_CHAT_INVALID_RESPONSE',
+      502,
+    );
+  }
+
+  return {
+    chatId: data.data.id,
+    memberIds: data.data.memberIds,
+    reused: Boolean(data.data.reused),
+  };
+}


### PR DESCRIPTION
### Motivation
- Implement Phase B2: create canonical UUID-backed private chats in relay/Postgres while preserving the legacy web/Prisma path and transport fallback. 
- Provide an idempotent server-side creation path so new one-to-one chats have canonical membership and enable subsequent Phase B3 delivery work. 
- Keep the change small, conservative, and reversible and avoid storing plaintext or E2EE private key material server-side. 

### Description
- Added a nullable `chats.private_pair_key` column and a partial unique index plus migration `services/relay/drizzle/0001_phase_b2_private_chat_creation.sql` to support idempotent private chat creation using a sorted `userA:userB` pair key. 
- Implemented an internal relay upsert endpoint at `POST /internal/chats/private/upsert` that resolves recipient identity (relay UUID or legacy web id), creates/synchronizes a relay user when needed, and runs a transactional upsert that creates the `chats` row and `chat_members` rows atomically; the route is protected by the existing `INTERNAL_API_KEY` bearer auth. 
- Added a web-side helper `createCanonicalPrivateChat` that uses the Phase B1 identity bridge to resolve the requester, resolves recipient (legacy or UUID), and calls the internal relay upsert; added public web route `POST /api/chats/private` which implements the requested API contract and returns `{ id, type, memberIds, mode: 'canonical_postgres' }`. 
- Updated the existing `POST /api/chats` private branch to delegate to the canonical helper for `type: 'private'` while leaving legacy/group creation untouched to preserve compatibility and fallback behavior. 
- Files changed: `services/relay/src/routes/internal.ts`, `services/relay/src/db/schema.ts`, `services/relay/drizzle/0001_phase_b2_private_chat_creation.sql`, `src/lib/server/relay-private-chat.ts`, `src/app/api/chats/private/route.ts`, and `src/app/api/chats/route.ts`. 
- Duplicate-prevention strategy: `private_pair_key = sort(userAId, userBId).join(':')` with a partial unique index; on upsert the implementation looks up existing pair key and inserts members with `ON CONFLICT DO NOTHING` to repair/reuse. 
- Security/privacy: no plaintext message or private key storage introduced, internal route requires `INTERNAL_API_KEY`, and code avoids logging secrets or raw key material. 

### Testing
- `pnpm install --no-frozen-lockfile` was attempted but failed in this environment due to npm registry 403 / missing auth; full workspace install could not complete. 
- Package builds/typechecks: `pnpm --filter @presidium/shared-types build` (passed), `pnpm --filter @presidium/shared-crypto build` (passed), `pnpm --filter @presidium/shared-ui build` (passed), `pnpm --filter @presidium/relay typecheck` (passed), `pnpm --filter @presidium/relay build` (passed), and `pnpm --filter @presidium/web typecheck` (passed). 
- Failing/blocked checks due to environment limitations: `pnpm --filter @presidium/shared-api build` (failed due to partial install/workspace resolution), `pnpm --filter @presidium/web build` (failed: `next` binary unavailable), and `docker compose config` (failed: `docker` not installed). 
- Note: full runtime two-user smoke tests (Postgres/Redis/Relay/WebSocket/Web UI) remain pending because the environment cannot run the required services; the patch includes the DB migration SQL so runtime validation can proceed once the infra is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11b9b34a0832aaa435d1032e52bbf)