### PR TITLE
fix: stabilize ai-worker typecheck

### DIFF
--- a/services/ai-worker/src/index.ts
+++ b/services/ai-worker/src/index.ts
@@ -13,10 +13,10 @@
  * Runs as a separate process, communicates via Redis (BullMQ queues).
  */
 
-import Redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { Worker } from 'bullmq';
-import { runRegexCheck, quickRegexCheck, getONNXInfo } from '@presidium/relay/moderation/rules';
-import { runONNXCheck, initONNX } from '@presidium/relay/moderation/onnx';
+import { runRegexCheck } from './moderation/rules.js';
+import { runONNXCheck, initONNX, getONNXInfo } from './moderation/onnx.js';
 
 // === CONFIG ===
 
@@ -84,12 +84,12 @@ async function main() {
   console.log('[AI-Worker] Starting Presidium AI Worker...');
 
   const redis = new Redis(REDIS_URL, { maxRetriesPerRequest: null });
-  redis.on('error', (err) => console.error('[AI-Worker] Redis error:', err));
+  redis.on('error', (err: Error) => console.error('[AI-Worker] Redis error:', err));
   redis.on('connect', () => console.log('[AI-Worker] Connected to Redis'));
 
   // Initialize ONNX models
   console.log('[AI-Worker] Initializing ONNX models...');
-  await initONNX().catch(err => console.warn('[AI-Worker] ONNX init failed:', err));
+  await initONNX().catch((err: Error) => console.warn('[AI-Worker] ONNX init failed:', err));
   console.log('[AI-Worker] ONNX status:', getONNXInfo());
 
   // === Silent Claw Worker ===

--- a/services/ai-worker/src/moderation/onnx.ts
+++ b/services/ai-worker/src/moderation/onnx.ts
@@ -1,0 +1,179 @@
+/**
+ * Tactical local copy of relay moderation logic.
+ *
+ * TODO: Move shared moderation logic into packages/shared-moderation
+ * and import it from both services/relay and services/ai-worker.
+ *
+ * This file exists to keep ai-worker typecheck/build stable without
+ * changing relay exports in this PR.
+ *
+ * @author Сергей Сергеевич Карнаух
+ * @copyright (C) 2026 Сергей Сергеевич Карнаух. All Rights Reserved.
+ *
+ * Silent Claw — Layer 2: ONNX Runtime (local copy for ai-worker)
+ *
+ * Локальный ML inference для toxicity detection.
+ * Используем quantized модели для скорости:
+ * - Xenova/toxic-bert (English)
+ * - Для русского: fine-tuned RuBERT-toxic
+ *
+ * Performance:
+ * - First load: 2-5s (model download/cache)
+ * - Inference: 20-50ms per text
+ * - Memory: ~100MB
+ *
+ * Fallback: если ONNX недоступен, пропускаем к LLM.
+ */
+
+export interface ONNXResult {
+  toxicity: number;
+  isToxic: boolean;
+  categories: {
+    toxic: number;
+    severeToxic: number;
+    obscene: number;
+    threat: number;
+    insult: number;
+    identityHate: number;
+  };
+  latencyMs: number;
+}
+
+type TransformersModule = {
+  pipeline: (task: string, model: string, options?: Record<string, unknown>) => Promise<(input: unknown, options?: Record<string, unknown>) => Promise<unknown>>;
+};
+
+let toxicityClassifier: ((input: unknown, options?: Record<string, unknown>) => Promise<unknown>) | null = null;
+let modelLoading = false;
+let modelError: Error | null = null;
+
+const MODEL_NAME = 'Xenova/toxic-bert';
+
+async function importTransformers(): Promise<TransformersModule> {
+  // @xenova/transformers is an optional runtime dependency for local moderation.
+  // Use runtime dynamic import to keep ai-worker typecheck/build independent from it.
+  const dynamicImport = new Function('specifier', 'return import(specifier)') as (specifier: string) => Promise<TransformersModule>;
+  return dynamicImport('@xenova/transformers');
+}
+
+/**
+ * Initialize ONNX model (lazy loading)
+ */
+export async function initONNX(): Promise<void> {
+  if (toxicityClassifier) return;
+  if (modelLoading) {
+    while (modelLoading) { await new Promise(r => setTimeout(r, 100)); }
+    return;
+  }
+
+  modelLoading = true;
+  console.log('[SilentClaw] Loading ONNX model:', MODEL_NAME);
+
+  try {
+    const start = Date.now();
+
+    const { pipeline } = await importTransformers();
+    toxicityClassifier = await pipeline('text-classification', MODEL_NAME, {
+      quantized: true,
+      cache_dir: './.cache/transformers',
+    });
+
+    console.log(`[SilentClaw] ONNX model loaded in ${Date.now() - start}ms`);
+  } catch (err) {
+    modelError = err as Error;
+    console.warn('[SilentClaw] ONNX unavailable (install @xenova/transformers):', err);
+  } finally {
+    modelLoading = false;
+  }
+}
+
+/**
+ * Run ONNX toxicity check
+ */
+export async function runONNXCheck(text: string): Promise<ONNXResult> {
+  const start = Date.now();
+
+  if (!toxicityClassifier && !modelError) { await initONNX(); }
+
+  if (!toxicityClassifier) {
+    return neutralResult(Date.now() - start);
+  }
+
+  try {
+    const truncated = text.slice(0, 2000);
+    const result = await toxicityClassifier(truncated, { top_k: 6 });
+
+    const scores: Record<string, number> = {};
+    for (const item of result as Array<{ label: string; score: number }>) {
+      scores[item.label] = item.score;
+    }
+
+    const toxicity = scores['toxic'] || 0;
+
+    return {
+      toxicity,
+      isToxic: toxicity > 0.85,
+      categories: {
+        toxic: scores['toxic'] || 0,
+        severeToxic: scores['severe_toxic'] || 0,
+        obscene: scores['obscene'] || 0,
+        threat: scores['threat'] || 0,
+        insult: scores['insult'] || 0,
+        identityHate: scores['identity_hate'] || 0,
+      },
+      latencyMs: Date.now() - start,
+    };
+  } catch (err) {
+    console.error('[SilentClaw] ONNX inference error:', err);
+    return neutralResult(Date.now() - start);
+  }
+}
+
+/**
+ * Batch check multiple texts
+ */
+export async function runONNXBatch(texts: string[]): Promise<ONNXResult[]> {
+  if (!toxicityClassifier) await initONNX();
+  if (!toxicityClassifier) return texts.map(() => neutralResult(0));
+
+  const start = Date.now();
+  try {
+    const results = await toxicityClassifier(texts, { top_k: 6 });
+    return (results as Array<Array<{ label: string; score: number }>>).map((result) => {
+      const scores: Record<string, number> = {};
+      for (const item of result) { scores[item.label] = item.score; }
+      const toxicity = scores['toxic'] || 0;
+      return {
+        toxicity,
+        isToxic: toxicity > 0.85,
+        categories: {
+          toxic: scores['toxic'] || 0,
+          severeToxic: scores['severe_toxic'] || 0,
+          obscene: scores['obscene'] || 0,
+          threat: scores['threat'] || 0,
+          insult: scores['insult'] || 0,
+          identityHate: scores['identity_hate'] || 0,
+        },
+        latencyMs: Math.round((Date.now() - start) / texts.length),
+      };
+    });
+  } catch (err) {
+    console.error('[SilentClaw] ONNX batch error:', err);
+    return texts.map(() => neutralResult(0));
+  }
+}
+
+export function isONNXAvailable(): boolean { return toxicityClassifier !== null; }
+
+export function getONNXInfo(): {
+  loaded: boolean; model: string; quantized: boolean; error?: string;
+} {
+  return { loaded: toxicityClassifier !== null, model: MODEL_NAME, quantized: true, error: modelError?.message };
+}
+
+function neutralResult(latencyMs: number): ONNXResult {
+  return {
+    toxicity: 0, isToxic: false, latencyMs,
+    categories: { toxic: 0, severeToxic: 0, obscene: 0, threat: 0, insult: 0, identityHate: 0 },
+  };
+}

--- a/services/ai-worker/src/moderation/rules.ts
+++ b/services/ai-worker/src/moderation/rules.ts
@@ -1,0 +1,208 @@
+/**
+ * Tactical local copy of relay moderation logic.
+ *
+ * TODO: Move shared moderation logic into packages/shared-moderation
+ * and import it from both services/relay and services/ai-worker.
+ *
+ * This file exists to keep ai-worker typecheck/build stable without
+ * changing relay exports in this PR.
+ *
+ * @author Сергей Сергеевич Карнаух
+ * @copyright (C) 2026 Сергей Сергеевич Карнаух. All Rights Reserved.
+ *
+ * Silent Claw — Layer 1: Regex Rules (local copy for ai-worker)
+ *
+ * Zero-latency pattern matching для известных нарушений.
+ * Обрабатывается синхронно, блокирует сообщение мгновенно.
+ */
+
+export interface RegexRule {
+  id: string;
+  category: 'drugs' | 'fraud' | 'violence' | 'spam' | 'nsfw';
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  patterns: RegExp[];
+  description: string;
+  contexts: Array<'message' | 'post' | 'comment' | 'marketplace' | 'username'>;
+  action: 'flag' | 'shadow_remove' | 'block';
+}
+
+export interface RegexMatch {
+  matched: boolean;
+  rule?: RegexRule;
+  matches: string[];
+  position: number;
+}
+
+function normalizeText(text: string): string {
+  return text
+    .replace(/[\u200B-\u200F\uFEFF]/g, '')
+    .normalize('NFKC')
+    .replace(/[０𝟎𝟘𝟢🄀⓪]/g, '0')
+    .replace(/[１𝟏𝟙𝟣⒈①]/g, '1')
+    .replace(/(\S)\s+(\S)/g, '$1$2')
+    .toLowerCase();
+}
+
+export const ENHANCED_RULES: RegexRule[] = [
+  {
+    id: 'drugs-001',
+    category: 'drugs',
+    severity: 'critical',
+    patterns: [
+      /купить\s*(?:меф|мефедрон|скорость|фен|амф|амфетамин|кокаин|героин|шишки|трав[ау]|марихуан[ау]|грибы|lsd|экстази|мдма|спайс|соль)/i,
+      /заклад[кки]\s*(?:меф|мефедрон|скорость|фен|амф|кокаин|героин|шишки|трав[ау]|марихуан[ау]|грибы|lsd|экстази|мдма|спайс)/i,
+      /(?:меф|мефедрон|скорость|фен|амф|кокаин|героин)\s*(?:купить|заклад|заказать|доставка)/i,
+    ],
+    description: 'Drug purchase keywords and dealer contacts',
+    contexts: ['message', 'post', 'comment', 'marketplace'],
+    action: 'shadow_remove',
+  },
+  {
+    id: 'drugs-002',
+    category: 'drugs',
+    severity: 'high',
+    patterns: [
+      /(?:наркотик[иы]|дур[ьм]|трав[кау]|шишки|гриб[ыов]|кислот[аы]|экстаз[иы]|мдма|спайс|соли)/i,
+      /(?:дилер|закладчик|курьер|поставщик)\s*(?:нужен|ищу|требуется)/i,
+    ],
+    description: 'Drug references and dealer recruitment',
+    contexts: ['message', 'post', 'comment'],
+    action: 'flag',
+  },
+  {
+    id: 'fraud-001',
+    category: 'fraud',
+    severity: 'high',
+    patterns: [
+      /выигрыш\s*(?:\d+[кkмm]?\s*руб|\$\d+[кkмm]?)/i,
+      /(?:поздравляем|вы\s*выиграли|вы\s*стали\s*победител)/i,
+      /(?:переведите|отправьте|заплатите)\s*(?:\d+[кkмm]?)\s*(?:руб|₽|\$)/i,
+      /(?:банк|сбербанк|тинькофф|альфа)\s*(?:заблокир|заморож|подозрительн)/i,
+      /(?:срочно|незамедлительно)\s*(?:подтвердите|подтверждение)/i,
+    ],
+    description: 'Fraud, scams, phishing attempts',
+    contexts: ['message', 'post', 'comment', 'marketplace'],
+    action: 'shadow_remove',
+  },
+  {
+    id: 'fraud-002',
+    category: 'fraud',
+    severity: 'medium',
+    patterns: [
+      /(?:заработок|заработать|доход|пассивный\s*доход)\s*(?:\d+[кkмm]?)\s*(?:руб|₽|\$)/i,
+      /(?:инвестиции|инвестировать|вложить)\s*(?:\d+[кkмm]?)/i,
+      /(?:пирамида|mlm|млм|сетевой\s*маркетинг)/i,
+    ],
+    description: 'Investment scams and MLM',
+    contexts: ['message', 'post', 'marketplace'],
+    action: 'flag',
+  },
+  {
+    id: 'violence-001',
+    category: 'violence',
+    severity: 'critical',
+    patterns: [
+      /(?:убей|убить|убийство|зарезать|застрелить|расстрел|взорвать|теракт)/i,
+      /(?:террорист|терроризм|экстремизм|радикал)/i,
+      /(?:нападение|захват|заложник|взрыв|бомб[ау])/i,
+    ],
+    description: 'Violence, terrorism, extremism',
+    contexts: ['message', 'post', 'comment'],
+    action: 'shadow_remove',
+  },
+  {
+    id: 'violence-002',
+    category: 'violence',
+    severity: 'high',
+    patterns: [
+      /(?:изнасилова|насилие|педофил|детское\s*порно|cp)/i,
+    ],
+    description: 'Sexual violence and CSAM references',
+    contexts: ['message', 'post', 'comment'],
+    action: 'block',
+  },
+  {
+    id: 'spam-001',
+    category: 'spam',
+    severity: 'medium',
+    patterns: [
+      /(?:подпишись|подписывайся|переходи|кликни|жми\s*сюда)/i,
+      /(?:реклама|продвижение|раскрутка|smm)/i,
+      /(?:бесплатно|даром|в\s*подарок)\s*(?:только\s*сегодня)/i,
+    ],
+    description: 'Spam and engagement bait',
+    contexts: ['message', 'post', 'comment'],
+    action: 'flag',
+  },
+  {
+    id: 'nsfw-001',
+    category: 'nsfw',
+    severity: 'medium',
+    patterns: [
+      /(?:порно|порнография|эротика|голые|ню|18\+|только\s*для\s*взрослых)/i,
+    ],
+    description: 'Adult content in public channels',
+    contexts: ['post', 'comment'],
+    action: 'flag',
+  },
+];
+
+const severityOrder: Record<string, number> = { low: 0, medium: 1, high: 2, critical: 3 };
+
+export function runRegexCheck(
+  text: string,
+  context: 'message' | 'post' | 'comment' | 'marketplace' | 'username' = 'message'
+): RegexMatch {
+  const normalized = normalizeText(text);
+  let bestMatch: RegexMatch = { matched: false, matches: [], position: -1 };
+  let highestSeverity = -1;
+
+  for (const rule of ENHANCED_RULES) {
+    if (!rule.contexts.includes(context)) continue;
+    for (const pattern of rule.patterns) {
+      const matches: string[] = [];
+      let match;
+      while ((match = pattern.exec(normalized)) !== null) {
+        matches.push(match[0]);
+        if (match.index === pattern.lastIndex) pattern.lastIndex++;
+      }
+      pattern.lastIndex = 0;
+      if (matches.length > 0) {
+        const sev = severityOrder[rule.severity];
+        if (sev > highestSeverity) {
+          highestSeverity = sev;
+          bestMatch = { matched: true, rule, matches, position: normalized.indexOf(matches[0]) };
+        }
+      }
+    }
+  }
+  return bestMatch;
+}
+
+export function quickRegexCheck(
+  text: string,
+  context: 'message' | 'post' | 'comment' | 'marketplace' | 'username' = 'message'
+): boolean {
+  const normalized = normalizeText(text);
+  for (const rule of ENHANCED_RULES) {
+    if (!rule.contexts.includes(context)) continue;
+    if (rule.severity !== 'critical') continue;
+    for (const pattern of rule.patterns) {
+      if (pattern.test(normalized)) { pattern.lastIndex = 0; return true; }
+      pattern.lastIndex = 0;
+    }
+  }
+  return false;
+}
+
+export function getRulesByCategory(category: RegexRule['category']): RegexRule[] {
+  return ENHANCED_RULES.filter(r => r.category === category);
+}
+
+export function addCustomRule(rule: RegexRule): void { ENHANCED_RULES.push(rule); }
+
+export function removeRule(ruleId: string): boolean {
+  const index = ENHANCED_RULES.findIndex(r => r.id === ruleId);
+  if (index >= 0) { ENHANCED_RULES.splice(index, 1); return true; }
+  return false;
+}


### PR DESCRIPTION
## Summary

Stabilizes `@presidium/ai-worker` typecheck after the cleanup of suspicious dependency changes.

## Scope

Changed only files under `services/ai-worker/**`:

- `services/ai-worker/src/index.ts`
- `services/ai-worker/src/moderation/rules.ts`
- `services/ai-worker/src/moderation/onnx.ts`

## Reported validation from GLM agent

- `pnpm --filter @presidium/ai-worker typecheck` passed
- `pnpm --filter @presidium/ai-worker build` passed
- full `pnpm typecheck` still fails in `@presidium/shared-api` because `@presidium/shared-types` cannot be resolved; this is outside the ai-worker scope

## Architectural review note

This PR keeps the change local to `services/ai-worker` by adding local moderation modules instead of changing `services/relay/package.json` exports. This satisfies the task constraints, but it introduces duplicated moderation logic between relay and ai-worker. Before merging, review whether this should be accepted as a tactical fix or replaced with a later shared moderation package.

## Guardrails

- No direct push to `main`
- No changes to `apps/web`
- No changes to `apps/mobile`
- No changes to `services/relay`
- No package manager / lockfile changes
- No workflow changes