### PR TITLE
fix: stabilize shared-api typecheck

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -3,6 +3,12 @@
   "version": "2.6.0",
   "author": "Presidium Maintainer <maintainer@local.dev>",
   "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes `@presidium/shared-api` typecheck resolution of `@presidium/shared-types` under `moduleResolution: NodeNext`.

## Scope

Changed exactly one file:

- `packages/shared-types/package.json`

## Root cause

`@presidium/shared-types` did not define package `exports`. With NodeNext resolution, TypeScript could not resolve the package unless `dist/` had already been built. That made `@presidium/shared-api` typecheck dependent on build order.

## Fix

Adds an `exports` map with a `types` condition pointing to source types and a runtime default pointing to the built artifact:

```json
"exports": {
  ".": {
    "types": "./src/index.ts",
    "default": "./dist/index.js"
  }
}
```

## Reported validation from GLM agent

- `pnpm --filter @presidium/shared-types typecheck` passed
- `pnpm --filter @presidium/shared-api typecheck` passed
- full `pnpm typecheck` now passes 6 of 7 packages
- remaining failure is in `@presidium/web`, which cannot resolve `@presidium/shared-ui` and `@presidium/shared-crypto`; this is outside this PR scope and will be handled separately

## Guardrails

- No direct push to `main`
- No app changes
- No service changes
- No lockfile changes
- No workflow changes
- No TypeScript strict-mode weakening