### PR TITLE
fix: stabilize web workspace package resolution

### DIFF
--- a/packages/shared-crypto/package.json
+++ b/packages/shared-crypto/package.json
@@ -3,6 +3,12 @@
   "version": "2.6.0",
   "author": "Presidium Maintainer <maintainer@local.dev>",
   "license": "MIT",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./styles": "./styles.css"


### PR DESCRIPTION
## Summary

Fixes `@presidium/web` TypeScript resolution for workspace packages under `moduleResolution: NodeNext`.

## Scope

Changed exactly two package manifests:

- `packages/shared-ui/package.json`
- `packages/shared-crypto/package.json`

## Root cause

`@presidium/web` could not resolve:

- `@presidium/shared-ui` because its package `exports.types` pointed at `./dist/index.d.ts`, which requires a prior build
- `@presidium/shared-crypto` because it did not define package `exports`

This made typecheck in a clean workspace depend on previously built `dist/` artifacts.

## Fix

- `@presidium/shared-ui`: point `exports["."].types` to `./src/index.ts` while preserving existing exports such as `./styles`
- `@presidium/shared-crypto`: add an `exports` map with `types` pointing to `./src/index.ts` and runtime default pointing to `./dist/index.js`

This follows the same workspace package pattern introduced for `@presidium/shared-types`.

## Reported validation from GLM agent

- `pnpm --filter @presidium/shared-ui typecheck` passed
- `pnpm --filter @presidium/shared-crypto typecheck` passed
- `pnpm --filter @presidium/web typecheck` passed
- `pnpm typecheck` passed across all 7 packages with 0 errors

## Guardrails

- No direct push to `main`
- No app source changes
- No service changes
- No package manager changes
- No lockfile changes
- No workflow changes
- No TypeScript strict-mode weakening