### PR TITLE
feat: add message repository contract with query types and outbox pat…

### DIFF
--- a/packages/shared-messaging/src/__tests__/delivery-and-repository.test.ts
+++ b/packages/shared-messaging/src/__tests__/delivery-and-repository.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for delivery types: OutboxEntry, RetryPolicy, computeRetryDelay.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  computeRetryDelay,
+  DEFAULT_RETRY_POLICY,
+} from '../delivery.js';
+
+import type { RetryPolicy } from '../delivery.js';
+
+import {
+  createMessageId,
+} from '../ids.js';
+
+import {
+  RepositoryNotFoundError,
+  RepositoryConcurrencyError,
+  RepositoryConflictError,
+} from '../errors.js';
+
+// ─── computeRetryDelay ──────────────────────────────────────────────────────
+
+describe('computeRetryDelay', () => {
+  it('returns baseDelayMs for the first retry (attempt 0)', () => {
+    expect(computeRetryDelay(0, DEFAULT_RETRY_POLICY)).toBe(1000);
+  });
+
+  it('doubles the delay for each subsequent attempt', () => {
+    expect(computeRetryDelay(1, DEFAULT_RETRY_POLICY)).toBe(2000);
+    expect(computeRetryDelay(2, DEFAULT_RETRY_POLICY)).toBe(4000);
+    expect(computeRetryDelay(3, DEFAULT_RETRY_POLICY)).toBe(8000);
+    expect(computeRetryDelay(4, DEFAULT_RETRY_POLICY)).toBe(16000);
+  });
+
+  it('caps the delay at maxDelayMs', () => {
+    // Attempt 5 would be 32000ms without cap, but max is 16000ms
+    expect(computeRetryDelay(5, DEFAULT_RETRY_POLICY)).toBe(16000);
+    // Even very high attempts are capped
+    expect(computeRetryDelay(100, DEFAULT_RETRY_POLICY)).toBe(16000);
+  });
+
+  it('works with a custom retry policy', () => {
+    const customPolicy: RetryPolicy = {
+      baseDelayMs: 500,
+      multiplier: 3,
+      maxDelayMs: 10000,
+      maxRetries: 10,
+    };
+
+    expect(computeRetryDelay(0, customPolicy)).toBe(500);
+    expect(computeRetryDelay(1, customPolicy)).toBe(1500);
+    expect(computeRetryDelay(2, customPolicy)).toBe(4500);
+    // 13500 would exceed maxDelayMs of 10000
+    expect(computeRetryDelay(3, customPolicy)).toBe(10000);
+  });
+
+  it('returns baseDelayMs for multiplier 1 (linear)', () => {
+    const linearPolicy: RetryPolicy = {
+      baseDelayMs: 2000,
+      multiplier: 1,
+      maxDelayMs: 5000,
+      maxRetries: 3,
+    };
+
+    expect(computeRetryDelay(0, linearPolicy)).toBe(2000);
+    expect(computeRetryDelay(1, linearPolicy)).toBe(2000);
+    expect(computeRetryDelay(2, linearPolicy)).toBe(2000);
+  });
+});
+
+// ─── DEFAULT_RETRY_POLICY ──────────────────────────────────────────────────
+
+describe('DEFAULT_RETRY_POLICY', () => {
+  it('has the expected default values', () => {
+    expect(DEFAULT_RETRY_POLICY.baseDelayMs).toBe(1000);
+    expect(DEFAULT_RETRY_POLICY.multiplier).toBe(2);
+    expect(DEFAULT_RETRY_POLICY.maxDelayMs).toBe(16000);
+    expect(DEFAULT_RETRY_POLICY.maxRetries).toBe(5);
+  });
+
+  it('has all readonly fields', () => {
+    // TypeScript enforces this at compile time, but we verify runtime immutability
+    const keys = Object.keys(DEFAULT_RETRY_POLICY) as (keyof RetryPolicy)[];
+    expect(keys).toEqual(['baseDelayMs', 'multiplier', 'maxDelayMs', 'maxRetries']);
+  });
+});
+
+// ─── RepositoryNotFoundError ────────────────────────────────────────────────
+
+describe('RepositoryNotFoundError', () => {
+  it('stores entity type and ID', () => {
+    const err = new RepositoryNotFoundError('Message', 'msg-123');
+    expect(err.name).toBe('RepositoryNotFoundError');
+    expect(err.entityType).toBe('Message');
+    expect(err.entityId).toBe('msg-123');
+    expect(err.message).toBe('Message not found: msg-123');
+  });
+
+  it('is an instance of MessagingDomainError and Error', () => {
+    const err = new RepositoryNotFoundError('OutboxEntry', 'msg-456');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(RepositoryNotFoundError);
+  });
+
+  it('works with branded message IDs', () => {
+    const id = createMessageId('msg-branded-1');
+    const err = new RepositoryNotFoundError('Message', id as string);
+    expect(err.entityId).toBe('msg-branded-1');
+  });
+});
+
+// ─── RepositoryConcurrencyError ─────────────────────────────────────────────
+
+describe('RepositoryConcurrencyError', () => {
+  it('stores version conflict details', () => {
+    const err = new RepositoryConcurrencyError('Message', 'msg-789', 3, 5);
+    expect(err.name).toBe('RepositoryConcurrencyError');
+    expect(err.entityType).toBe('Message');
+    expect(err.entityId).toBe('msg-789');
+    expect(err.expectedVersion).toBe(3);
+    expect(err.actualVersion).toBe(5);
+  });
+
+  it('includes versions in the error message', () => {
+    const err = new RepositoryConcurrencyError('Conversation', 'conv-1', 1, 2);
+    expect(err.message).toContain('expected version 1');
+    expect(err.message).toContain('got 2');
+    expect(err.message).toContain('Conversation');
+    expect(err.message).toContain('conv-1');
+  });
+
+  it('is an instance of MessagingDomainError and Error', () => {
+    const err = new RepositoryConcurrencyError('X', 'y', 0, 1);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(RepositoryConcurrencyError);
+  });
+});
+
+// ─── RepositoryConflictError ───────────────────────────────────────────────
+
+describe('RepositoryConflictError', () => {
+  it('stores conflict details', () => {
+    const err = new RepositoryConflictError(
+      'Message',
+      'msg-dup',
+      'unique constraint: messages.id',
+    );
+    expect(err.name).toBe('RepositoryConflictError');
+    expect(err.entityType).toBe('Message');
+    expect(err.entityId).toBe('msg-dup');
+    expect(err.constraint).toBe('unique constraint: messages.id');
+  });
+
+  it('includes all details in the error message', () => {
+    const err = new RepositoryConflictError(
+      'OutboxEntry',
+      'msg-out-1',
+      'unique constraint: outbox.message_id',
+    );
+    expect(err.message).toContain('OutboxEntry');
+    expect(err.message).toContain('msg-out-1');
+    expect(err.message).toContain('unique constraint: outbox.message_id');
+  });
+
+  it('is an instance of MessagingDomainError and Error', () => {
+    const err = new RepositoryConflictError('X', 'y', 'z');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(RepositoryConflictError);
+  });
+});

--- a/packages/shared-messaging/src/delivery.ts
+++ b/packages/shared-messaging/src/delivery.ts
@@ -2,16 +2,19 @@
  * @author Сергей Карнаух <sergynia96@gmail.com>
  * @copyright (C) 2026 Сергей Карнаух. All Rights Reserved.
  *
- * Delivery tracking types: OutboxMessage and InboxMessage.
+ * Delivery tracking types: OutboxMessage, InboxMessage, OutboxEntry,
+ * and retry policy configuration.
  *
  * OutboxMessage: a message the local device authored and is trying to send.
  * InboxMessage:  a message received from another participant.
+ * OutboxEntry:   a structured outbox record for the repository layer,
+ *                with version tracking, retry state, and timestamps.
  *
  * Both wrap a MessageEnvelope with additional delivery metadata.
  */
 
 import type { MessageEnvelope } from './message.js';
-import type { TimestampMs } from './ids.js';
+import type { TimestampMs, MessageId } from './ids.js';
 
 // ─── Outbox Message ─────────────────────────────────────────────────────────
 
@@ -43,3 +46,123 @@ export interface InboxMessage {
   /** If set, this message is a duplicate of the referenced MessageId. */
   duplicateOf?: MessageEnvelope['id'];
 }
+
+// ─── Outbox Status ───────────────────────────────────────────────────────────
+
+/**
+ * Lifecycle status of an outbox entry.
+ *
+ * State machine:
+ *   pending → sending → delivered
+ *   pending → retry → sending → delivered
+ *                      ↘ failed (retry budget exhausted)
+ *   pending → cancelled
+ *   retry → cancelled
+ *
+ * "pending" is the initial state when a message is first enqueued.
+ * "retry" is entered after a delivery failure when retries remain.
+ * "sending" is a transient state during active delivery (prevents concurrent sends).
+ * "delivered" and "failed" are terminal states.
+ * "cancelled" is a terminal state entered by user action.
+ */
+export type OutboxStatus = 'pending' | 'sending' | 'retry' | 'delivered' | 'failed' | 'cancelled';
+
+// ─── Outbox Entry ────────────────────────────────────────────────────────────
+
+/**
+ * A structured outbox record for the repository layer.
+ *
+ * Extends the concept of OutboxMessage with:
+ * - Explicit status field (OutboxStatus) for richer state tracking.
+ * - Version field for optimistic locking (future use).
+ * - Timestamps for lifecycle events (enqueued, sent, completed).
+ * - Typed association with MessageId (not the full envelope).
+ *
+ * The envelope is stored separately in the MessageRepository;
+ * this entry only holds the messageId reference for efficiency.
+ */
+export interface OutboxEntry {
+  /** The message this outbox entry tracks. */
+  readonly messageId: MessageId;
+  /** Current lifecycle status. */
+  readonly status: OutboxStatus;
+  /** Number of delivery attempts made so far. */
+  readonly retryCount: number;
+  /** Timestamp when the entry was first enqueued. */
+  readonly enqueuedAt: TimestampMs;
+  /** Timestamp of the last delivery attempt, if any. */
+  readonly lastAttemptAt?: TimestampMs;
+  /**
+   * Timestamp when the next retry should be attempted.
+   * Absent for "pending" (immediate first attempt) and terminal states.
+   */
+  readonly nextAttemptAt?: TimestampMs;
+  /** Description of the last failure, if any. */
+  readonly lastError?: string;
+  /**
+   * Optimistic locking version.
+   * Incremented on every update. Clients must provide the expected
+   * version when updating to detect concurrent modifications.
+   */
+  readonly version: number;
+  /** Timestamp when delivery was completed (delivered/failed/cancelled). */
+  readonly completedAt?: TimestampMs;
+}
+
+// ─── Retry Policy ───────────────────────────────────────────────────────────
+
+/**
+ * Configuration for exponential backoff retry behaviour.
+ *
+ * Controls how the outbox worker schedules retries after delivery failures.
+ * The backoff formula is: baseDelayMs * 2^attemptIndex, capped at maxDelayMs.
+ *
+ * Example with defaults:
+ *   Attempt 1: 1000ms (1s)
+ *   Attempt 2: 2000ms (2s)
+ *   Attempt 3: 4000ms (4s)
+ *   Attempt 4: 8000ms (8s)
+ *   Attempt 5: 16000ms (16s) — max reached
+ */
+export interface RetryPolicy {
+  /** Base delay in milliseconds for the first retry. */
+  readonly baseDelayMs: number;
+  /** Multiplier applied per retry attempt (exponential factor). */
+  readonly multiplier: number;
+  /** Maximum delay in milliseconds (caps exponential growth). */
+  readonly maxDelayMs: number;
+  /** Maximum number of retry attempts before giving up. */
+  readonly maxRetries: number;
+}
+
+// ─── Pure Functions ──────────────────────────────────────────────────────────
+
+/**
+ * Compute the delay before the next retry attempt using exponential backoff.
+ *
+ * Formula: min(baseDelayMs * multiplier ^ attempt, maxDelayMs)
+ *
+ * This is a pure function — no side effects, no Date.now().
+ * The caller is responsible for adding the delay to the current timestamp
+ * to produce the absolute nextAttemptAt value.
+ *
+ * @param attempt - Zero-based attempt index (0 = first retry, 1 = second, etc.).
+ * @param policy - The retry policy configuration.
+ * @returns The delay in milliseconds before the next attempt.
+ */
+export function computeRetryDelay(attempt: number, policy: RetryPolicy): number {
+  const exponentialDelay = policy.baseDelayMs * Math.pow(policy.multiplier, attempt);
+  return Math.min(exponentialDelay, policy.maxDelayMs);
+}
+
+/**
+ * Default retry policy: 1s base, 2x multiplier, 16s max, 5 retries.
+ *
+ * Produces the sequence: 1s → 2s → 4s → 8s → 16s → give up.
+ */
+export const DEFAULT_RETRY_POLICY: Readonly<RetryPolicy> = {
+  baseDelayMs: 1000,
+  multiplier: 2,
+  maxDelayMs: 16_000,
+  maxRetries: 5,
+} as const;

--- a/packages/shared-messaging/src/errors.ts
+++ b/packages/shared-messaging/src/errors.ts
@@ -77,3 +77,94 @@ export class InvalidConversationError extends MessagingDomainError {
     this.reason = reason;
   }
 }
+
+// ─── Repository Errors ───────────────────────────────────────────────────────
+
+/**
+ * Thrown when a repository operation targets an entity that does not exist.
+ *
+ * Common scenarios:
+ * - findById returns undefined, but caller expects existence.
+ * - updateStatus / delete called on a non-existent message.
+ * - markDelivered / cancel called on a non-existent outbox entry.
+ */
+export class RepositoryNotFoundError extends MessagingDomainError {
+  /** The type of entity that was not found (e.g., "Message", "OutboxEntry", "Conversation"). */
+  public readonly entityType: string;
+  /** The identifier that was searched for. */
+  public readonly entityId: string;
+
+  constructor(entityType: string, entityId: string) {
+    super(`${entityType} not found: ${entityId}`);
+    this.name = 'RepositoryNotFoundError';
+    this.entityType = entityType;
+    this.entityId = entityId;
+  }
+}
+
+/**
+ * Thrown when a repository operation fails due to an optimistic locking conflict.
+ *
+ * This occurs when the caller provides an expectedVersion that does not match
+ * the current version in storage, indicating that another process modified
+ * the entity between the caller's read and write operations.
+ *
+ * The caller should re-read the entity, reconcile changes, and retry.
+ */
+export class RepositoryConcurrencyError extends MessagingDomainError {
+  /** The type of entity with the version conflict. */
+  public readonly entityType: string;
+  /** The identifier of the conflicting entity. */
+  public readonly entityId: string;
+  /** The version the caller expected. */
+  public readonly expectedVersion: number;
+  /** The actual version currently stored. */
+  public readonly actualVersion: number;
+
+  constructor(
+    entityType: string,
+    entityId: string,
+    expectedVersion: number,
+    actualVersion: number,
+  ) {
+    super(
+      `Concurrency conflict on ${entityType} ${entityId}: ` +
+      `expected version ${expectedVersion}, got ${actualVersion}`,
+    );
+    this.name = 'RepositoryConcurrencyError';
+    this.entityType = entityType;
+    this.entityId = entityId;
+    this.expectedVersion = expectedVersion;
+    this.actualVersion = actualVersion;
+  }
+}
+
+/**
+ * Thrown when a repository operation violates a unique constraint.
+ *
+ * Common scenarios:
+ * - Saving a message with an ID that already exists.
+ * - Enqueuing an outbox entry for a message already in the outbox.
+ * - Creating a conversation with an ID that already exists.
+ *
+ * The caller should check for existence before retrying, or handle
+ * the duplicate gracefully (e.g., return the existing entity).
+ */
+export class RepositoryConflictError extends MessagingDomainError {
+  /** The type of entity with the unique constraint violation. */
+  public readonly entityType: string;
+  /** The identifier that caused the conflict. */
+  public readonly entityId: string;
+  /** Description of the constraint that was violated. */
+  public readonly constraint: string;
+
+  constructor(entityType: string, entityId: string, constraint: string) {
+    super(
+      `Conflict on ${entityType} ${entityId}: ${constraint}`,
+    );
+    this.name = 'RepositoryConflictError';
+    this.entityType = entityType;
+    this.entityId = entityId;
+    this.constraint = constraint;
+  }
+}

--- a/packages/shared-messaging/src/index.ts
+++ b/packages/shared-messaging/src/index.ts
@@ -43,6 +43,14 @@ export type {
 export type {
   OutboxMessage,
   InboxMessage,
+  OutboxStatus,
+  OutboxEntry,
+  RetryPolicy,
+} from './delivery.js';
+
+export {
+  computeRetryDelay,
+  DEFAULT_RETRY_POLICY,
 } from './delivery.js';
 
 // ─── Errors ──────────────────────────────────────────────────────────────────
@@ -51,6 +59,9 @@ export {
   InvalidDeliveryTransitionError,
   DuplicateMessageError,
   InvalidConversationError,
+  RepositoryNotFoundError,
+  RepositoryConcurrencyError,
+  RepositoryConflictError,
 } from './errors.js';
 
 // ─── State Helpers ───────────────────────────────────────────────────────────
@@ -64,3 +75,23 @@ export {
   registerInboundEnvelope,
   isDuplicateMessage,
 } from './state.js';
+
+// ─── Query Types ─────────────────────────────────────────────────────────────
+export type {
+  MessageSortField,
+  SortDirection,
+  SortOptions,
+  MessageFilter,
+  ConversationFilter,
+  CursorPagination,
+  OffsetPagination,
+  Pagination,
+  PaginatedResult,
+} from './query.js';
+
+// ─── Repository Interfaces ──────────────────────────────────────────────────
+export type {
+  MessageRepository,
+  OutboxRepository,
+  ConversationRepository,
+} from './repository.js';

--- a/packages/shared-messaging/src/query.ts
+++ b/packages/shared-messaging/src/query.ts
@@ -1,0 +1,177 @@
+/**
+ * @author Сергей Карнаух <sergynia96@gmail.com>
+ * @copyright (C) 2026 Сергей Карнаух. All Rights Reserved.
+ *
+ * Query types for repository layer.
+ *
+ * Provides pagination (cursor-based and offset-based), filtering,
+ * and sorting abstractions used by all repository interfaces.
+ *
+ * DESIGN DECISIONS:
+ * - Cursor-based pagination is the primary strategy for real-time
+ *   message feeds (stable under inserts, no page skips).
+ * - Offset-based pagination is provided for admin/audit queries
+ *   where absolute position matters more than performance.
+ * - All fields are readonly to enforce immutability at the type level.
+ */
+
+import type {
+  ConversationId,
+  MessageId,
+  UserId,
+  TimestampMs,
+} from './ids.js';
+
+import type { DeliveryStatus, MessageKind } from './message.js';
+
+// ─── Sort ────────────────────────────────────────────────────────────────────
+
+/**
+ * Fields available for sorting message queries.
+ *
+ * Each value maps to a physical column or computed field in the
+ * underlying storage engine. The repository implementation is
+ * responsible for translating these to the appropriate query.
+ */
+export type MessageSortField =
+  | 'createdAt'
+  | 'updatedAt'
+  | 'deliveryStatus'
+  | 'kind';
+
+/**
+ * Sort direction — ascending or descending.
+ */
+export type SortDirection = 'asc' | 'desc';
+
+/**
+ * Generic sort descriptor for ordered queries.
+ *
+ * @typeParam T - The specific sort field enum or union type.
+ *   Use MessageSortField for message queries, or extend
+ *   with domain-specific fields for other entities.
+ */
+export interface SortOptions<T extends string = MessageSortField> {
+  /** The field to sort by. */
+  readonly field: T;
+  /** Sort direction — defaults to 'desc' (newest first for timestamps). */
+  readonly direction: SortDirection;
+}
+
+// ─── Filters ─────────────────────────────────────────────────────────────────
+
+/**
+ * Filter criteria for message listing queries.
+ *
+ * All fields are optional — omitted fields are not applied.
+ * Multiple fields are combined with AND logic.
+ */
+export interface MessageFilter {
+  /** Only messages in this conversation. */
+  readonly conversationId?: ConversationId;
+  /** Only messages from this sender. */
+  readonly senderId?: UserId;
+  /** Only messages with this delivery status. */
+  readonly deliveryStatus?: DeliveryStatus;
+  /** Only messages of this kind (text, media, system). */
+  readonly kind?: MessageKind;
+  /** Only messages created at or after this timestamp (inclusive). */
+  readonly createdFrom?: TimestampMs;
+  /** Only messages created at or before this timestamp (inclusive). */
+  readonly createdTo?: TimestampMs;
+}
+
+/**
+ * Filter criteria for conversation listing queries.
+ *
+ * All fields are optional — omitted fields are not applied.
+ */
+export interface ConversationFilter {
+  /** Only conversations containing this participant. */
+  readonly participantId?: UserId;
+  /** Only conversations with unread count greater than zero. */
+  readonly hasUnread?: boolean;
+  /** Only conversations updated at or after this timestamp (inclusive). */
+  readonly updatedFrom?: TimestampMs;
+}
+
+// ─── Pagination ──────────────────────────────────────────────────────────────
+
+/**
+ * Cursor-based pagination parameters.
+ *
+ * The cursor is an opaque string encoding the position of the last
+ * item in the previous page. For message feeds, this is typically
+ * the message ID or (createdAt, id) tuple, ensuring stable ordering
+ * even when new messages are inserted between page fetches.
+ *
+ * Cursor pagination is the recommended strategy for:
+ * - Real-time message feeds
+ * - Infinite scroll UIs
+ * - Any dataset with frequent inserts
+ */
+export interface CursorPagination {
+  readonly type: 'cursor';
+  /**
+   * Opaque cursor from a previous PaginatedResult.
+   * Absent or undefined means "start from the beginning".
+   */
+  readonly cursor?: string;
+  /** Maximum number of items to return. Must be >= 1. */
+  readonly limit: number;
+}
+
+/**
+ * Offset-based pagination parameters.
+ *
+ * Uses a numeric offset into the result set. Simpler than cursor
+ * pagination but suffers from stability issues when items are
+ * inserted or deleted between page fetches (page drift).
+ *
+ * Recommended for:
+ * - Admin / audit queries where absolute position matters
+ * - Export/batch processing where consistency is less critical
+ */
+export interface OffsetPagination {
+  readonly type: 'offset';
+  /** Zero-based offset into the result set. */
+  readonly offset: number;
+  /** Maximum number of items to return. Must be >= 1. */
+  readonly limit: number;
+}
+
+/**
+ * Discriminated union of all pagination strategies.
+ *
+ * Use this type in repository method signatures to accept either
+ * pagination mode without overloading.
+ */
+export type Pagination = CursorPagination | OffsetPagination;
+
+// ─── Paginated Result ────────────────────────────────────────────────────────
+
+/**
+ * A page of results from a paginated query.
+ *
+ * Contains the items for the current page plus metadata for
+ * navigating to the next page. The cursor is an opaque string
+ * — consumers should NOT parse or construct cursors manually.
+ *
+ * @typeParam T - The type of items in the result set.
+ */
+export interface PaginatedResult<T> {
+  /** Items on the current page. */
+  readonly items: readonly T[];
+  /**
+   * Cursor for the next page.
+   * Absent if there are no more results (end of list).
+   */
+  readonly nextCursor?: string;
+  /**
+   * Whether more results exist beyond this page.
+   * Convenience flag — equivalent to checking nextCursor !== undefined.
+   */
+  readonly hasMore: boolean;
+  /** Total number of items matching the filter (may be approximate for large datasets). */
+  readonly totalCount?: number;
+}

--- a/packages/shared-messaging/src/repository.ts
+++ b/packages/shared-messaging/src/repository.ts
@@ -1,0 +1,323 @@
+/**
+ * @author Сергей Карнаух <sergynia96@gmail.com>
+ * @copyright (C) 2026 Сергей Карнаух. All Rights Reserved.
+ *
+ * Repository contract interfaces for the messaging domain.
+ *
+ * These are ABSTRACT interfaces — no implementation is provided here.
+ * Concrete implementations will be supplied by infrastructure packages
+ * (e.g., PostgreSQL, SQLite, in-memory for tests).
+ *
+ * DESIGN DECISIONS:
+ * - All methods return Promise<T> — repositories are inherently async.
+ * - Methods declare which errors they MAY throw via JSDoc.
+ *   Implementations are not required to throw these errors, but
+ *   callers must be prepared to handle them.
+ * - Version fields are included for future optimistic locking support.
+ *   Implementations may ignore them initially.
+ * - Both soft-delete (via status) and hard-delete are supported
+ *   for GDPR compliance.
+ */
+
+import type { MessageEnvelope, Conversation } from './message.js';
+import type { OutboxEntry } from './delivery.js';
+import type { MessageId, ConversationId, TimestampMs, UserId } from './ids.js';
+import type {
+  MessageFilter,
+  ConversationFilter,
+  SortOptions,
+  Pagination,
+  PaginatedResult,
+} from './query.js';
+
+// ─── MessageRepository ───────────────────────────────────────────────────────
+
+/**
+ * Abstract repository for message persistence and retrieval.
+ *
+ * Provides CRUD operations for MessageEnvelope entities,
+ * plus batch operations for efficient bulk processing.
+ *
+ * @throws {RepositoryNotFoundError} - On findById / delete when entity missing.
+ * @throws {RepositoryConcurrencyError} - On update when version mismatch.
+ * @throws {RepositoryConflictError} - On save when unique constraint violated.
+ */
+export interface MessageRepository {
+  /**
+   * Persist a new message envelope.
+   *
+   * @param message - The message to persist. Must not already exist.
+   * @returns The persisted message (with storage-generated fields if any).
+   * @throws {RepositoryConflictError} If a message with the same ID already exists.
+   */
+  save(message: MessageEnvelope): Promise<MessageEnvelope>;
+
+  /**
+   * Retrieve a message by its unique identifier.
+   *
+   * @param id - The MessageId to look up.
+   * @returns The message envelope, or undefined if not found.
+   */
+  findById(id: MessageId): Promise<MessageEnvelope | undefined>;
+
+  /**
+   * List messages in a conversation with optional filtering and pagination.
+   *
+   * @param conversationId - The conversation to list messages for.
+   * @param pagination - Pagination strategy (cursor or offset).
+   * @param sort - Optional sort options. Defaults to createdAt desc.
+   * @param filter - Optional additional filters (sender, status, kind, time range).
+   * @returns A paginated result of message envelopes.
+   */
+  findByConversation(
+    conversationId: ConversationId,
+    pagination: Pagination,
+    sort?: SortOptions,
+    filter?: MessageFilter,
+  ): Promise<PaginatedResult<MessageEnvelope>>;
+
+  /**
+   * Update the delivery status of an existing message.
+   *
+   * Performs an atomic status transition. The implementation should
+   * verify that the transition is valid according to the state machine
+   * defined in state.ts (or delegate to transitionDeliveryStatus).
+   *
+   * @param id - The message to update.
+   * @param status - The new delivery status.
+   * @param expectedVersion - Optional version for optimistic locking.
+   *   If provided, the update is rejected if the stored version differs.
+   * @returns The updated message envelope.
+   * @throws {RepositoryNotFoundError} If the message does not exist.
+   * @throws {RepositoryConcurrencyError} If the version does not match.
+   */
+  updateStatus(
+    id: MessageId,
+    status: MessageEnvelope['deliveryStatus'],
+    expectedVersion?: number,
+  ): Promise<MessageEnvelope>;
+
+  /**
+   * Soft-delete a message by moving it to "deleted" status.
+   *
+   * The message remains in storage but is excluded from normal queries.
+   * Use hardDelete for permanent removal (GDPR compliance).
+   *
+   * @param id - The message to soft-delete.
+   * @throws {RepositoryNotFoundError} If the message does not exist.
+   */
+  softDelete(id: MessageId): Promise<void>;
+
+  /**
+   * Permanently remove a message from storage.
+   *
+   * This operation is irreversible. Use for GDPR "right to be forgotten"
+   * or explicit user action. Prefer softDelete for general cases.
+   *
+   * @param id - The message to remove.
+   * @throws {RepositoryNotFoundError} If the message does not exist.
+   */
+  hardDelete(id: MessageId): Promise<void>;
+
+  /**
+   * List messages matching a filter with pagination and sorting.
+   *
+   * A general-purpose query method for admin, audit, or search use cases.
+   *
+   * @param filter - Filter criteria.
+   * @param pagination - Pagination strategy.
+   * @param sort - Sort options. Defaults to createdAt desc.
+   * @returns A paginated result of matching message envelopes.
+   */
+  find(
+    filter: MessageFilter,
+    pagination: Pagination,
+    sort?: SortOptions,
+  ): Promise<PaginatedResult<MessageEnvelope>>;
+
+  /**
+   * Count messages matching a filter.
+   *
+   * @param filter - Filter criteria. If omitted, counts all messages.
+   * @returns The total count of matching messages.
+   */
+  count(filter?: MessageFilter): Promise<number>;
+}
+
+// ─── OutboxRepository ────────────────────────────────────────────────────────
+
+/**
+ * Abstract repository for outbox (delivery tracking) persistence.
+ *
+ * The outbox pattern decouples message sending from delivery tracking:
+ * messages are written to the outbox first, then a background worker
+ * polls for pending entries and drives the delivery pipeline.
+ *
+ * @throws {RepositoryNotFoundError} - On operations targeting a missing entry.
+ * @throws {RepositoryConcurrencyError} - On retry update when version mismatch.
+ */
+export interface OutboxRepository {
+  /**
+   * Add a new entry to the outbox for delivery tracking.
+   *
+   * @param entry - The outbox entry to enqueue.
+   * @returns The persisted entry (with storage-generated fields if any).
+   * @throws {RepositoryConflictError} If an entry with the same messageId already exists.
+   */
+  enqueue(entry: OutboxEntry): Promise<OutboxEntry>;
+
+  /**
+   * Retrieve a pending outbox entry by its associated message ID.
+   *
+   * @param messageId - The MessageId the outbox entry tracks.
+   * @returns The outbox entry, or undefined if not found.
+   */
+  findByMessageId(messageId: MessageId): Promise<OutboxEntry | undefined>;
+
+  /**
+   * List outbox entries that are due for a retry attempt.
+   *
+   * Returns entries where status is "pending" or "retry" AND
+   * nextAttemptAt is <= the provided current timestamp.
+   *
+   * @param now - The current timestamp to compare against nextAttemptAt.
+   * @param limit - Maximum number of entries to return.
+   * @returns Outbox entries ready for retry, ordered by nextAttemptAt asc.
+   */
+  findDueForRetry(now: TimestampMs, limit: number): Promise<readonly OutboxEntry[]>;
+
+  /**
+   * Mark an outbox entry as successfully delivered.
+   *
+   * @param messageId - The message that was delivered.
+   * @param deliveredAt - The timestamp of successful delivery.
+   * @throws {RepositoryNotFoundError} If no outbox entry exists for the message.
+   */
+  markDelivered(messageId: MessageId, deliveredAt: TimestampMs): Promise<void>;
+
+  /**
+   * Record a failed delivery attempt and schedule a retry.
+   *
+   * Increments retryCount, computes the next retry time using the
+   * RetryPolicy, and transitions the entry to "retry" status.
+   * If the retry budget is exhausted, transitions to "failed".
+   *
+   * @param messageId - The message that failed.
+   * @param error - Description of the failure reason.
+   * @param failedAt - The timestamp of the failure.
+   * @throws {RepositoryNotFoundError} If no outbox entry exists for the message.
+   */
+  markFailed(messageId: MessageId, error: string, failedAt: TimestampMs): Promise<void>;
+
+  /**
+   * Cancel a pending outbox entry.
+   *
+   * The entry is moved to "cancelled" status and will not be retried.
+   *
+   * @param messageId - The message to cancel delivery for.
+   * @throws {RepositoryNotFoundError} If no outbox entry exists for the message.
+   */
+  cancel(messageId: MessageId): Promise<void>;
+
+  /**
+   * Purge completed outbox entries older than the given timestamp.
+   *
+   * Removes entries in "delivered" or "cancelled" status that were
+   * completed before the specified threshold. Used for housekeeping
+   * to prevent unbounded outbox growth.
+   *
+   * @param completedBefore - Purge entries completed before this timestamp.
+   * @returns The number of entries purged.
+   */
+  purgeCompleted(completedBefore: TimestampMs): Promise<number>;
+}
+
+// ─── ConversationRepository ──────────────────────────────────────────────────
+
+/**
+ * Abstract repository for conversation metadata persistence.
+ *
+ * Stores conversation-level data: participant lists, unread counts,
+ * last-message pointers, and timestamps. Does NOT store messages
+ * themselves — use MessageRepository for that.
+ *
+ * @throws {RepositoryNotFoundError} - On operations targeting a missing conversation.
+ * @throws {RepositoryConflictError} - On create when unique constraint violated.
+ */
+export interface ConversationRepository {
+  /**
+   * Create a new conversation.
+   *
+   * @param conversation - The conversation to create. Must not already exist.
+   * @returns The persisted conversation.
+   * @throws {RepositoryConflictError} If a conversation with the same ID exists.
+   */
+  save(conversation: Conversation): Promise<Conversation>;
+
+  /**
+   * Retrieve a conversation by its unique identifier.
+   *
+   * @param id - The ConversationId to look up.
+   * @returns The conversation, or undefined if not found.
+   */
+  findById(id: ConversationId): Promise<Conversation | undefined>;
+
+  /**
+   * List conversations for a given participant with pagination.
+   *
+   * @param participantId - The user whose conversations to list.
+   * @param pagination - Pagination strategy.
+   * @param sort - Sort options. Defaults to updatedAt desc.
+   * @param filter - Optional additional filters (hasUnread, updatedFrom).
+   * @returns A paginated result of conversations.
+   */
+  findByParticipant(
+    participantId: UserId,
+    pagination: Pagination,
+    sort?: SortOptions,
+    filter?: ConversationFilter,
+  ): Promise<PaginatedResult<Conversation>>;
+
+  /**
+   * Update conversation metadata.
+   *
+   * Used to update unreadCount, lastMessageId, updatedAt, and
+   * participant lists (e.g., when adding/removing group members).
+   *
+   * @param id - The conversation to update.
+   * @param updates - Partial set of fields to update.
+   * @param expectedVersion - Optional version for optimistic locking.
+   * @returns The updated conversation.
+   * @throws {RepositoryNotFoundError} If the conversation does not exist.
+   * @throws {RepositoryConcurrencyError} If the version does not match.
+   */
+  update(
+    id: ConversationId,
+    updates: Partial<Pick<Conversation, 'participantIds' | 'lastMessageId' | 'unreadCount' | 'updatedAt'>>,
+    expectedVersion?: number,
+  ): Promise<Conversation>;
+
+  /**
+   * Remove a conversation and all its messages.
+   *
+   * Implementations should cascade the delete to associated messages
+   * in the MessageRepository, or use a database-level foreign key
+   * constraint with ON DELETE CASCADE.
+   *
+   * @param id - The conversation to remove.
+   * @throws {RepositoryNotFoundError} If the conversation does not exist.
+   */
+  delete(id: ConversationId): Promise<void>;
+
+  /**
+   * Atomically increment the unread count for a conversation.
+   *
+   * Thread-safe operation that ensures the count is accurate
+   * even under concurrent message arrivals.
+   *
+   * @param conversationId - The conversation to increment.
+   * @param delta - The amount to add (positive to increment, negative to decrement).
+   * @throws {RepositoryNotFoundError} If the conversation does not exist.
+   */
+  incrementUnreadCount(conversationId: ConversationId, delta: number): Promise<void>;
+}


### PR DESCRIPTION
…tern

New files:
- query.ts: Cursor/offset pagination, filtering, sorting (SortOptions, MessageFilter, ConversationFilter, Pagination, PaginatedResult<T>)
- repository.ts: MessageRepository, OutboxRepository, ConversationRepository interfaces with full JSDoc and error contract documentation
- __tests__/delivery-and-repository.test.ts: 16 tests for computeRetryDelay, DEFAULT_RETRY_POLICY, and 3 new repository error classes

Modified files:
- delivery.ts: OutboxStatus union, OutboxEntry interface with version tracking and lifecycle timestamps, RetryPolicy interface, computeRetryDelay pure function, DEFAULT_RETRY_POLICY constant
- errors.ts: RepositoryNotFoundError, RepositoryConcurrencyError, RepositoryConflictError — all extending MessagingDomainError
- index.ts: Re-exports for all new types, interfaces, functions, and constants

Architecture decisions:
- Cursor-based pagination as primary strategy (real-time feeds)
- Version field for optimistic locking (migration-ready)
- Both soft-delete and hard-delete on MessageRepository (GDPR)
- Exponential backoff: 1s→2s→4s→8s→16s, max 5 retries
- Outbox pattern with status state machine (pending→sending→delivered)
- All repos in shared-messaging as contract-only interfaces