### PR TITLE
chore(relay): integrate @presidium/shared-messaging domain types

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       '@presidium/shared-crypto':
         specifier: workspace:*
         version: link:../../packages/shared-crypto
+      '@presidium/shared-messaging':
+        specifier: workspace:*
+        version: link:../../packages/shared-messaging
       '@presidium/shared-moderation':
         specifier: workspace:*
         version: link:../../packages/shared-moderation

--- a/services/relay/package.json
+++ b/services/relay/package.json
@@ -32,6 +32,7 @@
     "zod": "^3.24.0",
     "@presidium/shared-types": "workspace:*",
     "@presidium/shared-crypto": "workspace:*",
+    "@presidium/shared-messaging": "workspace:*",
     "@presidium/shared-moderation": "workspace:*"
   },
   "devDependencies": {

--- a/services/relay/src/types/messaging.ts
+++ b/services/relay/src/types/messaging.ts
@@ -1,0 +1,102 @@
+/**
+ * @author Сергей Карнаух <sergynia96@gmail.com>
+ * @copyright (C) 2026 Сергей Карнаух. All Rights Reserved.
+ *
+ * Re-exports from @presidium/shared-messaging for use in relay.
+ *
+ * This is the single integration point between domain contract and infrastructure.
+ *
+ * RULES:
+ * - Only re-export what relay actually needs.
+ * - Don't add relay-specific logic here (use adapters for that).
+ * - Keep this file sorted alphabetically within each section.
+ * - Error classes use `export {}` (not `export type {}`) because they are
+ *   runtime values needed for `throw` and `instanceof`.
+ */
+
+// ─── Branded IDs ─────────────────────────────────────────────────────────────
+export type {
+  ConversationId,
+  DeviceId,
+  MessageId,
+  MessageClientNonce,
+  TimestampMs,
+  UserId,
+} from '@presidium/shared-messaging';
+
+export {
+  createConversationId,
+  createDeviceId,
+  createMessageId,
+  createMessageClientNonce,
+  createTimestampMs,
+  createUserId,
+} from '@presidium/shared-messaging';
+
+// ─── Domain Models ───────────────────────────────────────────────────────────
+export type {
+  Conversation,
+  DeliveryStatus,
+  EncryptedPayload,
+  MessageDirection,
+  MessageEnvelope,
+  MessageKind,
+  PlaintextDraft,
+} from '@presidium/shared-messaging';
+
+// ─── Delivery & Outbox ───────────────────────────────────────────────────────
+export type {
+  InboxMessage,
+  OutboxEntry,
+  OutboxMessage,
+  OutboxStatus,
+  RetryPolicy,
+} from '@presidium/shared-messaging';
+
+export {
+  computeRetryDelay,
+  DEFAULT_RETRY_POLICY,
+} from '@presidium/shared-messaging';
+
+// ─── Errors (runtime values — classes) ───────────────────────────────────────
+export {
+  DuplicateMessageError,
+  InvalidConversationError,
+  InvalidDeliveryTransitionError,
+  MessagingDomainError,
+  RepositoryConflictError,
+  RepositoryConcurrencyError,
+  RepositoryNotFoundError,
+} from '@presidium/shared-messaging';
+
+// ─── Query Types ─────────────────────────────────────────────────────────────
+export type {
+  ConversationFilter,
+  CursorPagination,
+  MessageFilter,
+  MessageSortField,
+  OffsetPagination,
+  PaginatedResult,
+  Pagination,
+  SortDirection,
+  SortOptions,
+} from '@presidium/shared-messaging';
+
+// ─── Repository Interfaces ──────────────────────────────────────────────────
+export type {
+  ConversationRepository,
+  MessageRepository,
+  OutboxRepository,
+} from '@presidium/shared-messaging';
+
+// ─── State Helpers (pure functions, no side effects) ─────────────────────────
+export {
+  canTransitionDeliveryStatus,
+  createConversation,
+  createOutboundEnvelope,
+  isDuplicateMessage,
+  markDelivered,
+  markRead,
+  registerInboundEnvelope,
+  transitionDeliveryStatus,
+} from '@presidium/shared-messaging';


### PR DESCRIPTION
- Add @presidium/shared-messaging as workspace dependency to relay
- Create services/relay/src/types/messaging.ts barrel re-export
- Re-exports: branded IDs (6 types + 6 ctors), domain models (7 types), delivery types (5 types + 2 values), error classes (7 classes), query types (9 types), repository interfaces (3 interfaces), state helpers (8 pure functions)
- Typecheck passes (0 new errors; 2 pre-existing tweetnacl errors in shared-crypto are unrelated)